### PR TITLE
Default to l3v2

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -424,7 +424,7 @@ stages:
         continueOnError: "false"
         pool:
           vmImage: 'ubuntu-latest'
-        container: sysbiouw/roadrunner-manylinux2014-base:latest
+        container: sysbiouw/roadrunner-manylinux2014:latest
         variables:
           CCACHE_DIR: '$(Pipeline.Workspace)/ccache'
           BUILD_DIRECTORY: '$(System.DefaultWorkingDirectory)/build'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -423,7 +423,7 @@ stages:
         displayName: LinuxBuildAntimonyCpp
         continueOnError: "false"
         pool:
-          vmImage: 'ubuntu-18.04'
+          vmImage: 'ubuntu-latest'
         container: sysbiouw/roadrunner-manylinux2014-base:latest
         variables:
           CCACHE_DIR: '$(Pipeline.Workspace)/ccache'

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -47,7 +47,7 @@ Module::Module(string name)
     m_currentexportvar(0),
     m_ismain(false),
     m_sbmllevel(3),
-    m_sbmlversion(1),
+    m_sbmlversion(2),
     m_varmap(),
 #ifndef NSBML
 #ifdef USE_COMP

--- a/src/sbmlx.cpp
+++ b/src/sbmlx.cpp
@@ -645,6 +645,27 @@ void elideMetaIds(SBMLDocument* doc)
   delete elts;
 }
 
+void unlistEmptyLists(SBMLDocument* doc)
+{
+    Model* model = doc->getModel();
+    model->getListOfCompartments()->setExplicitlyListed(false);
+    model->getListOfSpecies()->setExplicitlyListed(false);
+    model->getListOfReactions()->setExplicitlyListed(false);
+    model->getListOfParameters()->setExplicitlyListed(false);
+    model->getListOfFunctionDefinitions()->setExplicitlyListed(false);
+    model->getListOfUnitDefinitions()->setExplicitlyListed(false);
+    model->getListOfInitialAssignments()->setExplicitlyListed(false);
+    model->getListOfRules()->setExplicitlyListed(false);
+    model->getListOfConstraints()->setExplicitlyListed(false);
+    model->getListOfEvents()->setExplicitlyListed(false);
+    for (unsigned int r = 0; r < model->getNumReactions(); r++) {
+        Reaction* rxn = model->getReaction(r);
+        rxn->getListOfModifiers()->setExplicitlyListed(false);
+        rxn->getListOfProducts()->setExplicitlyListed(false);
+        rxn->getListOfReactants()->setExplicitlyListed(false);
+    }
+}
+
 std::string elideMetaIdsFromSBMLstring(std::string sbml)
 {
   SBMLReader reader;

--- a/src/sbmlx.h
+++ b/src/sbmlx.h
@@ -40,6 +40,7 @@ void elideMetaIds(libsbml::SBMLDocument* doc);
 /// Same thing using sbml string as input / output
 std::string elideMetaIdsFromSBMLstring(std::string sbml);
 
+void unlistEmptyLists(libsbml::SBMLDocument* doc);
 
 constraint_type getConstraintTypeFrom(libsbml::ASTNodeType_t asttype);
 #ifdef LIBSBML_HAS_PACKAGE_FBC

--- a/src/test/TestAntimonyAPI.cpp
+++ b/src/test/TestAntimonyAPI.cpp
@@ -177,11 +177,11 @@ START_TEST (test_getStrings)
   char* model = getAntimonyString(NULL);
   fail_unless(string(model) == (string)"// Created by libAntimony " + LIBANTIMONY_VERSION_STRING + "\n// Variable initializations:\na = 3;\n");
   char* sbml = getSBMLString(NULL);
-  fail_unless(string(sbml) == "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<sbml xmlns=\"http://www.sbml.org/sbml/level3/version1/core\" level=\"3\" version=\"1\">\n  <model metaid=\"__main\" id=\"__main\">\n    <listOfParameters>\n      <parameter id=\"a\" value=\"3\" constant=\"true\"/>\n    </listOfParameters>\n  </model>\n</sbml>\n");
+  fail_unless(string(sbml) == "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<sbml xmlns=\"http://www.sbml.org/sbml/level3/version2/core\" level=\"3\" version=\"2\">\n  <model metaid=\"__main\" id=\"__main\">\n    <listOfParameters>\n      <parameter id=\"a\" value=\"3\" constant=\"true\"/>\n    </listOfParameters>\n  </model>\n</sbml>\n");
   sbml = getCompSBMLString(NULL);
-  fail_unless(string(sbml) == "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<sbml xmlns=\"http://www.sbml.org/sbml/level3/version1/core\" xmlns:comp=\"http://www.sbml.org/sbml/level3/version1/comp/version1\" level=\"3\" version=\"1\" comp:required=\"true\">\n  <model metaid=\"__main\" id=\"__main\">\n    <listOfParameters>\n      <parameter id=\"a\" value=\"3\" constant=\"true\"/>\n    </listOfParameters>\n  </model>\n</sbml>\n");
+  fail_unless(string(sbml) == "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<sbml xmlns=\"http://www.sbml.org/sbml/level3/version2/core\" xmlns:comp=\"http://www.sbml.org/sbml/level3/version1/comp/version1\" level=\"3\" version=\"2\" comp:required=\"true\">\n  <model metaid=\"__main\" id=\"__main\">\n    <listOfParameters>\n      <parameter id=\"a\" value=\"3\" constant=\"true\"/>\n    </listOfParameters>\n  </model>\n</sbml>\n");
   sbml = getSBMLString(NULL);
-  fail_unless(string(sbml) == "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<sbml xmlns=\"http://www.sbml.org/sbml/level3/version1/core\" level=\"3\" version=\"1\">\n  <model metaid=\"__main\" id=\"__main\">\n    <listOfParameters>\n      <parameter id=\"a\" value=\"3\" constant=\"true\"/>\n    </listOfParameters>\n  </model>\n</sbml>\n");
+  fail_unless(string(sbml) == "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<sbml xmlns=\"http://www.sbml.org/sbml/level3/version2/core\" level=\"3\" version=\"2\">\n  <model metaid=\"__main\" id=\"__main\">\n    <listOfParameters>\n      <parameter id=\"a\" value=\"3\" constant=\"true\"/>\n    </listOfParameters>\n  </model>\n</sbml>\n");
 
   freeAll();
   clearPreviousLoads();
@@ -196,7 +196,7 @@ START_TEST (test_getCellML)
 #ifndef NCELLML
   //This function crashes for NO REASON.  I use exactly the same 
   char* cellml = getCellMLString(NULL);
-  fail_unless(string(cellml) == "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<sbml xmlns=\"http://www.sbml.org/sbml/level3/version1/core\" level=\"3\" version=\"1\">\n  <model id=\"__main\" name=\"__main\">\n    <listOfParameters>\n      <parameter id=\"a\" value=\"3\" constant=\"true\"/>\n    </listOfParameters>\n  </model>\n</sbml>\n");
+  fail_unless(string(cellml) == "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<sbml xmlns=\"http://www.sbml.org/sbml/level3/version2/core\" level=\"3\" version=\"2\">\n  <model id=\"__main\" name=\"__main\">\n    <listOfParameters>\n      <parameter id=\"a\" value=\"3\" constant=\"true\"/>\n    </listOfParameters>\n  </model>\n</sbml>\n");
 #endif
   freeAll();
   clearPreviousLoads();
@@ -229,7 +229,7 @@ END_TEST
 
 START_TEST (test_loadAntimonyStringErrSBML)
 {
-  long ret = loadAntimonyString("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<sbml xmlns=\"http://www.sbml.org/sbml/level3/version1/core\" level=\"3\" version=\"1\">\n  <model id=\"__main\" name=\"__main\">\n    <listOfParameters>\n      <parameter id=\"a\" value=\"3\" constant=\"true\"/>\n    </listOfParameters>\n  </model>\n</sbml>\n");
+  long ret = loadAntimonyString("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<sbml xmlns=\"http://www.sbml.org/sbml/level3/version2/core\" level=\"3\" version=\"2\">\n  <model id=\"__main\" name=\"__main\">\n    <listOfParameters>\n      <parameter id=\"a\" value=\"3\" constant=\"true\"/>\n    </listOfParameters>\n  </model>\n</sbml>\n");
   fail_unless (ret == -1);
   string err = "The provided string is actually an SBML model, and is not in the Antimony format.  Use 'loadString' or 'loadSBMLString' to correctly parse it.";
   fail_unless (string(getLastError()) == err);
@@ -284,7 +284,7 @@ END_TEST
 
 START_TEST (test_loadSBMLString)
 {
-  long ret = loadSBMLString("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<sbml xmlns=\"http://www.sbml.org/sbml/level3/version1/core\" level=\"3\" version=\"1\">\n  <model id=\"__main\" name=\"__main\">\n    <listOfParameters>\n      <parameter id=\"a\" value=\"3\" constant=\"true\"/>\n    </listOfParameters>\n  </model>\n</sbml>\n");
+  long ret = loadSBMLString("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<sbml xmlns=\"http://www.sbml.org/sbml/level3/version2/core\" level=\"3\" version=\"2\">\n  <model id=\"__main\" name=\"__main\">\n    <listOfParameters>\n      <parameter id=\"a\" value=\"3\" constant=\"true\"/>\n    </listOfParameters>\n  </model>\n</sbml>\n");
   char* model = getAntimonyString(NULL);
   fail_unless(string(model) == (string)"// Created by libAntimony " + LIBANTIMONY_VERSION_STRING + "\n// Variable initializations:\na = 3;\n\n// Other declarations:\nconst a;\n");
 
@@ -324,7 +324,7 @@ START_TEST (test_loadSBMLStringWithLocation)
   dir += "from-libsbml/";
   long ret = loadSBMLStringWithLocation("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
 "<!-- The file 'new_aggregate.xml' is actually in the subdirectory 'subdir', so you have to tell the converter to look there, or this model cannot be flattened.-->"
-"<sbml xmlns=\"http://www.sbml.org/sbml/level3/version1/core\" xmlns:comp=\"http://www.sbml.org/sbml/level3/version1/comp/version1\" level=\"3\" version=\"1\" comp:required=\"true\">"
+"<sbml xmlns=\"http://www.sbml.org/sbml/level3/version2/core\" xmlns:comp=\"http://www.sbml.org/sbml/level3/version1/comp/version1\" level=\"3\" version=\"2\" comp:required=\"true\">"
 "  <model>"
 "    <comp:listOfSubmodels>"
 "      <comp:submodel comp:id=\"A\" comp:modelRef=\"EM1\"/>"
@@ -676,7 +676,7 @@ START_TEST (test_dimensionless)
   setBareNumbersAreDimensionless(true);
 
   char* sbml = getSBMLString(NULL);
-  fail_unless(string(sbml) == "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<sbml xmlns=\"http://www.sbml.org/sbml/level3/version1/core\" level=\"3\" version=\"1\">\n  <model metaid=\"__main\" id=\"__main\">\n    <listOfParameters>\n      <parameter id=\"a\" constant=\"true\"/>\n    </listOfParameters>\n    <listOfInitialAssignments>\n      <initialAssignment symbol=\"a\">\n        <math xmlns=\"http://www.w3.org/1998/Math/MathML\" xmlns:sbml=\"http://www.sbml.org/sbml/level3/version1/core\">\n          <apply>\n            <plus/>\n            <cn sbml:units=\"dimensionless\" type=\"integer\"> 3 </cn>\n            <cn sbml:units=\"dimensionless\" type=\"integer\"> 2 </cn>\n          </apply>\n        </math>\n      </initialAssignment>\n    </listOfInitialAssignments>\n  </model>\n</sbml>\n");
+  fail_unless(string(sbml) == "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<sbml xmlns=\"http://www.sbml.org/sbml/level3/version2/core\" level=\"3\" version=\"2\">\n  <model metaid=\"__main\" id=\"__main\">\n    <listOfParameters>\n      <parameter id=\"a\" constant=\"true\"/>\n    </listOfParameters>\n    <listOfInitialAssignments>\n      <initialAssignment symbol=\"a\">\n        <math xmlns=\"http://www.w3.org/1998/Math/MathML\" xmlns:sbml=\"http://www.sbml.org/sbml/level3/version2/core\">\n          <apply>\n            <plus/>\n            <cn sbml:units=\"dimensionless\" type=\"integer\"> 3 </cn>\n            <cn sbml:units=\"dimensionless\" type=\"integer\"> 2 </cn>\n          </apply>\n        </math>\n      </initialAssignment>\n    </listOfInitialAssignments>\n  </model>\n</sbml>\n");
   setBareNumbersAreDimensionless(false);
 
   freeAll();

--- a/src/test/TestAntimonyHierarchy.cpp
+++ b/src/test/TestAntimonyHierarchy.cpp
@@ -51,6 +51,7 @@ void compareFileHierarchy(const string& base)
   // fail if conversion was not valid
   fail_unless(result == LIBSBML_OPERATION_SUCCESS);
   elideMetaIds(doc);
+  unlistEmptyLists(doc);
   string sbmlFlat = writeSBMLToStdString(doc);
   string atosbml_nometa = elideMetaIdsFromSBMLstring(atosbml);
   fail_unless(atosbml_nometa == sbmlFlat);

--- a/src/test/test-data/BIOMD0000000118.xml
+++ b/src/test/test-data/BIOMD0000000118.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.13.0 with libSBML version 5.18.1. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" level="3" version="1">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2">
   <model metaid="model_0000001" id="model_0000001" name="Golomb2006_SomaticBursting">
     <listOfFunctionDefinitions>
       <functionDefinition id="GAMMA">

--- a/src/test/test-data/BIOMD0000000696.xml
+++ b/src/test/test-data/BIOMD0000000696.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.13.0 with libSBML version 5.18.1. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" metaid="cea100b3-db67-45de-ad56-90d64fbc6a29" level="3" version="1">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" metaid="cea100b3-db67-45de-ad56-90d64fbc6a29" level="3" version="2">
   <model metaid="COPASI0" id="Boada2016___Incoherent_type_1_feed_forward_loop__I1_FFL" name="Boada2016 - Incoherent type 1 feed-forward loop (I1-FFL)">
     <listOfFunctionDefinitions>
       <functionDefinition metaid="ec33b9b5-838e-4560-af2b-f2014752795c" id="rateOf">

--- a/src/test/test-data/SBO_compartment.xml
+++ b/src/test/test-data/SBO_compartment.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.12.0 with libSBML version 5.18.0. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000025" id="a" spatialDimensions="3" constant="true"/>

--- a/src/test/test-data/SBO_event.xml
+++ b/src/test/test-data/SBO_event.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.12.0 with libSBML version 5.18.0. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter id="b" constant="false"/>

--- a/src/test/test-data/SBO_function.xml
+++ b/src/test/test-data/SBO_function.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.12.0 with libSBML version 5.18.0. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfFunctionDefinitions>
       <functionDefinition sboTerm="SBO:0000008" id="foo">

--- a/src/test/test-data/SBO_localvar.xml
+++ b/src/test/test-data/SBO_localvar.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.12.0 with libSBML version 5.18.0. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="foo" id="foo">
     <listOfParameters>
       <parameter id="sboTerm" value="5" constant="true"/>

--- a/src/test/test-data/SBO_module.xml
+++ b/src/test/test-data/SBO_module.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.12.0 with libSBML version 5.18.0. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="foo" sboTerm="SBO:0000008" id="foo"/>
 </sbml>

--- a/src/test/test-data/SBO_param.xml
+++ b/src/test/test-data/SBO_param.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.12.0 with libSBML version 5.18.0. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter sboTerm="SBO:0000025" id="a" constant="true"/>

--- a/src/test/test-data/SBO_param2.xml
+++ b/src/test/test-data/SBO_param2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.12.0 with libSBML version 5.18.0. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter sboTerm="SBO:0000025" id="a" value="3" constant="true"/>

--- a/src/test/test-data/SBO_reaction.xml
+++ b/src/test/test-data/SBO_reaction.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.12.0 with libSBML version 5.18.0. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
@@ -9,7 +9,7 @@
       <species id="A" compartment="default_compartment" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfReactions>
-      <reaction sboTerm="SBO:0000888" id="J0" reversible="true" fast="false">
+      <reaction sboTerm="SBO:0000888" id="J0" reversible="true">
         <listOfReactants>
           <speciesReference species="A" stoichiometry="1" constant="true"/>
         </listOfReactants>

--- a/src/test/test-data/SBO_species.xml
+++ b/src/test/test-data/SBO_species.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.12.0 with libSBML version 5.18.0. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>

--- a/src/test/test-data/SBO_submodel.xml
+++ b/src/test/test-data/SBO_submodel.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.12.0 with libSBML version 5.18.0. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <comp:listOfSubmodels>
       <comp:submodel sboTerm="SBO:0000008" comp:id="A" comp:modelRef="foo"/>

--- a/src/test/test-data/SBO_submodel_shadowed.xml
+++ b/src/test/test-data/SBO_submodel_shadowed.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.12.0 with libSBML version 5.18.0. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter id="b" value="3" constant="true">

--- a/src/test/test-data/assignmentRule.xml
+++ b/src/test/test-data/assignmentRule.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter id="x" value="4.8" constant="false"/>

--- a/src/test/test-data/coefficientOfVariation.xml
+++ b/src/test/test-data/coefficientOfVariation.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.12.0 with libSBML version 5.18.0. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" level="3" version="1" comp:required="true" distrib:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" level="3" version="2" comp:required="true" distrib:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter id="a" constant="true">

--- a/src/test/test-data/compartment.xml
+++ b/src/test/test-data/compartment.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfCompartments>
       <compartment id="y" spatialDimensions="3" constant="true"/>

--- a/src/test/test-data/compound_units1.xml
+++ b/src/test/test-data/compound_units1.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfUnitDefinitions>
       <unitDefinition id="voltage">

--- a/src/test/test-data/compound_units2.xml
+++ b/src/test/test-data/compound_units2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfUnitDefinitions>
       <unitDefinition id="voltage">

--- a/src/test/test-data/compound_units3.xml
+++ b/src/test/test-data/compound_units3.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfUnitDefinitions>
       <unitDefinition id="voltage">

--- a/src/test/test-data/compound_units4.xml
+++ b/src/test/test-data/compound_units4.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfUnitDefinitions>
       <unitDefinition id="persecondsq">

--- a/src/test/test-data/confidenceInterval.xml
+++ b/src/test/test-data/confidenceInterval.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.12.0 with libSBML version 5.18.1. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" level="3" version="1" comp:required="true" distrib:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" level="3" version="2" comp:required="true" distrib:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter id="a" constant="true">

--- a/src/test/test-data/constraints/numeric_constraints.xml
+++ b/src/test/test-data/constraints/numeric_constraints.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter id="x" constant="true"/>

--- a/src/test/test-data/constraints/numeric_constraints_neg.xml
+++ b/src/test/test-data/constraints/numeric_constraints_neg.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter id="x" constant="true"/>

--- a/src/test/test-data/constraints/three_level_constraints.xml
+++ b/src/test/test-data/constraints/three_level_constraints.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter id="x" constant="true"/>

--- a/src/test/test-data/credibleInterval.xml
+++ b/src/test/test-data/credibleInterval.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.12.0 with libSBML version 5.18.1. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" level="3" version="1" comp:required="true" distrib:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" level="3" version="2" comp:required="true" distrib:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter id="a" constant="true">

--- a/src/test/test-data/defaultOrNotCompartment.xml
+++ b/src/test/test-data/defaultOrNotCompartment.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="baz" id="baz">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true">

--- a/src/test/test-data/defaultSubCompartment.xml
+++ b/src/test/test-data/defaultSubCompartment.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar" id="bar">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true">

--- a/src/test/test-data/defaultSubSubCompartment.xml
+++ b/src/test/test-data/defaultSubSubCompartment.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="baz" id="baz">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true">

--- a/src/test/test-data/default_compartment.xml
+++ b/src/test/test-data/default_compartment.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.13.0 with libSBML version 5.18.1. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" level="3" version="1">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2">
   <model metaid="def_comp" id="def_comp">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
@@ -9,7 +9,7 @@
       <species id="S1" compartment="default_compartment" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfReactions>
-      <reaction id="_J0" reversible="true" fast="false">
+      <reaction id="_J0" reversible="true">
         <listOfReactants>
           <speciesReference species="S1" stoichiometry="1" constant="true"/>
         </listOfReactants>

--- a/src/test/test-data/deleteAssignmentRuleDirect.xml
+++ b/src/test/test-data/deleteAssignmentRuleDirect.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar1" id="bar1">
     <listOfParameters>
       <parameter id="x" constant="false">

--- a/src/test/test-data/deleteAssignmentRuleIndirect.xml
+++ b/src/test/test-data/deleteAssignmentRuleIndirect.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar1" id="bar1">
     <comp:listOfSubmodels>
       <comp:submodel comp:id="A" comp:modelRef="foo">

--- a/src/test/test-data/deleteAssignmentRuleOfAnother.xml
+++ b/src/test/test-data/deleteAssignmentRuleOfAnother.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar1" id="bar1">
     <comp:listOfSubmodels>
       <comp:submodel comp:id="A" comp:modelRef="foo">

--- a/src/test/test-data/deleteDelay.xml
+++ b/src/test/test-data/deleteDelay.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar" id="bar">
     <comp:listOfSubmodels>
       <comp:submodel comp:id="A" comp:modelRef="foo">

--- a/src/test/test-data/deleteDelay2.xml
+++ b/src/test/test-data/deleteDelay2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar" id="bar">
     <comp:listOfSubmodels>
       <comp:submodel comp:id="A" comp:modelRef="foo">

--- a/src/test/test-data/deleteEventAssignment.xml
+++ b/src/test/test-data/deleteEventAssignment.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar" id="bar">
     <comp:listOfSubmodels>
       <comp:submodel comp:id="A" comp:modelRef="foo">

--- a/src/test/test-data/deleteEventAssignment2.xml
+++ b/src/test/test-data/deleteEventAssignment2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar" id="bar">
     <comp:listOfSubmodels>
       <comp:submodel comp:id="A" comp:modelRef="foo">

--- a/src/test/test-data/deleteEventAssignment3.xml
+++ b/src/test/test-data/deleteEventAssignment3.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar" id="bar">
     <comp:listOfSubmodels>
       <comp:submodel comp:id="A" comp:modelRef="foo">

--- a/src/test/test-data/deleteEventAssignment4.xml
+++ b/src/test/test-data/deleteEventAssignment4.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar" id="bar">
     <comp:listOfSubmodels>
       <comp:submodel comp:id="A" comp:modelRef="foo">

--- a/src/test/test-data/deleteEventAssignment5.xml
+++ b/src/test/test-data/deleteEventAssignment5.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar" id="bar">
     <comp:listOfSubmodels>
       <comp:submodel comp:id="A" comp:modelRef="foo">

--- a/src/test/test-data/deleteInitialAssignmentDirect.xml
+++ b/src/test/test-data/deleteInitialAssignmentDirect.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar1" id="bar1">
     <listOfParameters>
       <parameter id="x" constant="true">

--- a/src/test/test-data/deleteInitialAssignmentIndirect.xml
+++ b/src/test/test-data/deleteInitialAssignmentIndirect.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar1" id="bar1">
     <comp:listOfSubmodels>
       <comp:submodel comp:id="A" comp:modelRef="foo">

--- a/src/test/test-data/deleteInitialAssignmentOfAnother.xml
+++ b/src/test/test-data/deleteInitialAssignmentOfAnother.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar1" id="bar1">
     <comp:listOfSubmodels>
       <comp:submodel comp:id="A" comp:modelRef="foo">

--- a/src/test/test-data/deleteKineticLaw.xml
+++ b/src/test/test-data/deleteKineticLaw.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar1" id="bar1">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true">
@@ -29,7 +29,7 @@
         <parameter id="K1" constant="true"/>
       </listOfParameters>
       <listOfReactions>
-        <reaction id="J1" reversible="true" fast="false">
+        <reaction id="J1" reversible="true">
           <listOfReactants>
             <speciesReference species="S1" stoichiometry="1" constant="true"/>
           </listOfReactants>

--- a/src/test/test-data/deleteModifier.xml
+++ b/src/test/test-data/deleteModifier.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar1" id="bar1">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true">
@@ -27,7 +27,7 @@
         <species id="S1" compartment="default_compartment" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
       </listOfSpecies>
       <listOfReactions>
-        <reaction id="J1" reversible="true" fast="false">
+        <reaction id="J1" reversible="true">
           <listOfReactants>
             <speciesReference species="S1" stoichiometry="1" constant="true"/>
           </listOfReactants>

--- a/src/test/test-data/deleteModifierKineticLaw.xml
+++ b/src/test/test-data/deleteModifierKineticLaw.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar1" id="bar1">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true">
@@ -31,7 +31,7 @@
         <parameter id="K1" constant="true"/>
       </listOfParameters>
       <listOfReactions>
-        <reaction id="J1" reversible="true" fast="false">
+        <reaction id="J1" reversible="true">
           <listOfReactants>
             <speciesReference species="S1" stoichiometry="1" constant="true"/>
           </listOfReactants>

--- a/src/test/test-data/deletePriority.xml
+++ b/src/test/test-data/deletePriority.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar" id="bar">
     <comp:listOfSubmodels>
       <comp:submodel comp:id="A" comp:modelRef="foo">

--- a/src/test/test-data/deletePriority2.xml
+++ b/src/test/test-data/deletePriority2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar" id="bar">
     <comp:listOfSubmodels>
       <comp:submodel comp:id="A" comp:modelRef="foo">

--- a/src/test/test-data/deleteProduct.xml
+++ b/src/test/test-data/deleteProduct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar1" id="bar1">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true">
@@ -30,7 +30,7 @@
         <parameter id="K1" constant="true"/>
       </listOfParameters>
       <listOfReactions>
-        <reaction id="J1" reversible="true" fast="false">
+        <reaction id="J1" reversible="true">
           <listOfReactants>
             <speciesReference species="S1" stoichiometry="1" constant="true"/>
           </listOfReactants>

--- a/src/test/test-data/deleteRateRuleDirect.xml
+++ b/src/test/test-data/deleteRateRuleDirect.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar1" id="bar1">
     <listOfParameters>
       <parameter id="x" constant="false">

--- a/src/test/test-data/deleteRateRuleIndirect.xml
+++ b/src/test/test-data/deleteRateRuleIndirect.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar1" id="bar1">
     <comp:listOfSubmodels>
       <comp:submodel comp:id="A" comp:modelRef="foo">

--- a/src/test/test-data/deleteRateRuleOfAnother.xml
+++ b/src/test/test-data/deleteRateRuleOfAnother.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar1" id="bar1">
     <comp:listOfSubmodels>
       <comp:submodel comp:id="A" comp:modelRef="foo">

--- a/src/test/test-data/deleteReactant.xml
+++ b/src/test/test-data/deleteReactant.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar1" id="bar1">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true">
@@ -30,7 +30,7 @@
         <parameter id="K1" constant="true"/>
       </listOfParameters>
       <listOfReactions>
-        <reaction id="J1" reversible="true" fast="false">
+        <reaction id="J1" reversible="true">
           <listOfReactants>
             <speciesReference metaid="J1__reactant__S1" species="S1" stoichiometry="1" constant="true"/>
           </listOfReactants>

--- a/src/test/test-data/deleteReaction.xml
+++ b/src/test/test-data/deleteReaction.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar1" id="bar1">
     <comp:listOfSubmodels>
       <comp:submodel comp:id="A" comp:modelRef="foo">
@@ -21,7 +21,7 @@
         <parameter id="K1" constant="true"/>
       </listOfParameters>
       <listOfReactions>
-        <reaction id="J1" reversible="true" fast="false">
+        <reaction id="J1" reversible="true">
           <listOfReactants>
             <speciesReference species="S1" stoichiometry="1" constant="true"/>
           </listOfReactants>

--- a/src/test/test-data/deleteSpecies.xml
+++ b/src/test/test-data/deleteSpecies.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar1" id="bar1">
     <comp:listOfSubmodels>
       <comp:submodel comp:id="A" comp:modelRef="foo">

--- a/src/test/test-data/deleteSpeciesInDefaultCompartment.xml
+++ b/src/test/test-data/deleteSpeciesInDefaultCompartment.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar1" id="bar1">
     <comp:listOfSubmodels>
       <comp:submodel comp:id="A" comp:modelRef="foo">

--- a/src/test/test-data/deleteSpeciesInDefaultCompartment2.xml
+++ b/src/test/test-data/deleteSpeciesInDefaultCompartment2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar1" id="bar1">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true">

--- a/src/test/test-data/deleteSpeciesPort.xml
+++ b/src/test/test-data/deleteSpeciesPort.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar1" id="bar1">
     <comp:listOfSubmodels>
       <comp:submodel comp:id="A" comp:modelRef="foo">

--- a/src/test/test-data/deleteSpeciesPortDefaultCompartment.xml
+++ b/src/test/test-data/deleteSpeciesPortDefaultCompartment.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar1" id="bar1">
     <comp:listOfSubmodels>
       <comp:submodel comp:id="A" comp:modelRef="foo">

--- a/src/test/test-data/deleteTrigger.xml
+++ b/src/test/test-data/deleteTrigger.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar" id="bar">
     <comp:listOfSubmodels>
       <comp:submodel comp:id="A" comp:modelRef="foo">

--- a/src/test/test-data/deletion.xml
+++ b/src/test/test-data/deletion.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar" id="bar">
     <comp:listOfSubmodels>
       <comp:submodel comp:id="A" comp:modelRef="foo">

--- a/src/test/test-data/distribution.xml
+++ b/src/test/test-data/distribution.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.12.0 with libSBML version 5.18.1. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" level="3" version="1" comp:required="true" distrib:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" level="3" version="2" comp:required="true" distrib:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter id="a" constant="true">

--- a/src/test/test-data/distributions/numeric_distributions.xml
+++ b/src/test/test-data/distributions/numeric_distributions.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" level="3" version="1" comp:required="true" distrib:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" level="3" version="2" comp:required="true" distrib:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter id="a" constant="true"/>

--- a/src/test/test-data/distributions/numeric_distributions_extended.xml
+++ b/src/test/test-data/distributions/numeric_distributions_extended.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" level="3" version="1" comp:required="true" distrib:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" level="3" version="2" comp:required="true" distrib:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter id="a" constant="true"/>

--- a/src/test/test-data/distributions/numeric_distributions_rev.xml
+++ b/src/test/test-data/distributions/numeric_distributions_rev.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" level="3" version="1" comp:required="true" distrib:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" level="3" version="2" comp:required="true" distrib:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter id="a" constant="true"/>

--- a/src/test/test-data/empty_cvterm.xml
+++ b/src/test/test-data/empty_cvterm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.12.0 with libSBML version 5.18.0. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter id="a" constant="true"/>

--- a/src/test/test-data/encodes.xml
+++ b/src/test/test-data/encodes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.12.0 with libSBML version 5.18.0. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter metaid="__main.a" id="a" value="3" constant="true">

--- a/src/test/test-data/event.xml
+++ b/src/test/test-data/event.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter id="x" constant="false"/>

--- a/src/test/test-data/eventDelay.xml
+++ b/src/test/test-data/eventDelay.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter id="x" constant="false"/>

--- a/src/test/test-data/eventFromTrigger.xml
+++ b/src/test/test-data/eventFromTrigger.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter id="x" constant="false"/>

--- a/src/test/test-data/eventPersistent.xml
+++ b/src/test/test-data/eventPersistent.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter id="x" constant="false"/>

--- a/src/test/test-data/eventPriority.xml
+++ b/src/test/test-data/eventPriority.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter id="x" constant="false"/>

--- a/src/test/test-data/eventT0.xml
+++ b/src/test/test-data/eventT0.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter id="x" constant="false"/>

--- a/src/test/test-data/externalParameter1.xml
+++ b/src/test/test-data/externalParameter1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.12.0 with libSBML version 5.18.1. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" level="3" version="1" comp:required="true" distrib:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" level="3" version="2" comp:required="true" distrib:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter id="a" constant="true">

--- a/src/test/test-data/externalParameter2.xml
+++ b/src/test/test-data/externalParameter2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.12.0 with libSBML version 5.18.1. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" level="3" version="1" comp:required="true" distrib:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" level="3" version="2" comp:required="true" distrib:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter id="a" constant="true">

--- a/src/test/test-data/externalParameter3.xml
+++ b/src/test/test-data/externalParameter3.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.12.0 with libSBML version 5.18.1. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" level="3" version="1" comp:required="true" distrib:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" level="3" version="2" comp:required="true" distrib:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter id="a" constant="true">

--- a/src/test/test-data/fbc/fluxes_and_objectives.xml
+++ b/src/test/test-data/fbc/fluxes_and_objectives.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:fbc="http://www.sbml.org/sbml/level3/version1/fbc/version1" level="3" version="1" comp:required="true" fbc:required="false">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:fbc="http://www.sbml.org/sbml/level3/version1/fbc/version1" level="3" version="2" comp:required="true" fbc:required="false">
   <model metaid="__main" id="__main">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
@@ -52,22 +52,22 @@
       </constraint>
     </listOfConstraints>
     <listOfReactions>
-      <reaction id="J0" reversible="true" fast="false">
+      <reaction id="J0" reversible="true">
         <listOfReactants>
           <speciesReference species="s1" stoichiometry="1" constant="true"/>
         </listOfReactants>
       </reaction>
-      <reaction id="J1" reversible="true" fast="false">
+      <reaction id="J1" reversible="true">
         <listOfReactants>
           <speciesReference species="s2" stoichiometry="1" constant="true"/>
         </listOfReactants>
       </reaction>
-      <reaction id="J2" reversible="true" fast="false">
+      <reaction id="J2" reversible="true">
         <listOfReactants>
           <speciesReference species="s3" stoichiometry="1" constant="true"/>
         </listOfReactants>
       </reaction>
-      <reaction id="J3" reversible="true" fast="false">
+      <reaction id="J3" reversible="true">
         <listOfProducts>
           <speciesReference species="s1" stoichiometry="1" constant="true"/>
         </listOfProducts>

--- a/src/test/test-data/fbc/formula_objective.xml
+++ b/src/test/test-data/fbc/formula_objective.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:fbc="http://www.sbml.org/sbml/level3/version1/fbc/version1" level="3" version="1" comp:required="true" fbc:required="false">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:fbc="http://www.sbml.org/sbml/level3/version1/fbc/version1" level="3" version="2" comp:required="true" fbc:required="false">
   <model metaid="__main" id="__main">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
@@ -8,7 +8,7 @@
       <species id="s1" compartment="default_compartment" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfReactions>
-      <reaction id="J0" reversible="true" fast="false">
+      <reaction id="J0" reversible="true">
         <listOfReactants>
           <speciesReference species="s1" stoichiometry="1" constant="true"/>
         </listOfReactants>

--- a/src/test/test-data/fbc/formula_objective2.xml
+++ b/src/test/test-data/fbc/formula_objective2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:fbc="http://www.sbml.org/sbml/level3/version1/fbc/version1" level="3" version="1" comp:required="true" fbc:required="false">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:fbc="http://www.sbml.org/sbml/level3/version1/fbc/version1" level="3" version="2" comp:required="true" fbc:required="false">
   <model metaid="__main" id="__main">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
@@ -8,7 +8,7 @@
       <species id="s1" compartment="default_compartment" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfReactions>
-      <reaction id="J0" reversible="true" fast="false">
+      <reaction id="J0" reversible="true">
         <listOfReactants>
           <speciesReference species="s1" stoichiometry="1" constant="true"/>
         </listOfReactants>

--- a/src/test/test-data/fbc/simple_flux.xml
+++ b/src/test/test-data/fbc/simple_flux.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:fbc="http://www.sbml.org/sbml/level3/version1/fbc/version1" level="3" version="1" comp:required="true" fbc:required="false">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:fbc="http://www.sbml.org/sbml/level3/version1/fbc/version1" level="3" version="2" comp:required="true" fbc:required="false">
   <model metaid="__main" id="__main">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
@@ -19,7 +19,7 @@
       </constraint>
     </listOfConstraints>
     <listOfReactions>
-      <reaction id="J0" reversible="true" fast="false">
+      <reaction id="J0" reversible="true">
         <listOfReactants>
           <speciesReference species="s1" stoichiometry="1" constant="true"/>
         </listOfReactants>

--- a/src/test/test-data/fbc/simple_flux2.xml
+++ b/src/test/test-data/fbc/simple_flux2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:fbc="http://www.sbml.org/sbml/level3/version1/fbc/version1" level="3" version="1" comp:required="true" fbc:required="false">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:fbc="http://www.sbml.org/sbml/level3/version1/fbc/version1" level="3" version="2" comp:required="true" fbc:required="false">
   <model metaid="__main" id="__main">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
@@ -19,7 +19,7 @@
       </constraint>
     </listOfConstraints>
     <listOfReactions>
-      <reaction id="J0" reversible="true" fast="false">
+      <reaction id="J0" reversible="true">
         <listOfReactants>
           <speciesReference species="s1" stoichiometry="1" constant="true"/>
         </listOfReactants>

--- a/src/test/test-data/fbc/simple_flux3.xml
+++ b/src/test/test-data/fbc/simple_flux3.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.7.0 on 2015-03-13 15:18 with libSBML version 5.11.3. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:fbc="http://www.sbml.org/sbml/level3/version1/fbc/version1" level="3" version="1" comp:required="true" fbc:required="false">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:fbc="http://www.sbml.org/sbml/level3/version1/fbc/version1" level="3" version="2" comp:required="true" fbc:required="false">
   <model metaid="__main" id="__main">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
@@ -48,12 +48,12 @@
       </constraint>
     </listOfConstraints>
     <listOfReactions>
-      <reaction id="J0" reversible="true" fast="false">
+      <reaction id="J0" reversible="true">
         <listOfReactants>
           <speciesReference species="s1" stoichiometry="1" constant="true"/>
         </listOfReactants>
       </reaction>
-      <reaction id="J1" reversible="true" fast="false">
+      <reaction id="J1" reversible="true">
         <listOfReactants>
           <speciesReference species="s2" stoichiometry="1" constant="true"/>
         </listOfReactants>

--- a/src/test/test-data/fbc/simple_flux3_reverse.xml
+++ b/src/test/test-data/fbc/simple_flux3_reverse.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:fbc="http://www.sbml.org/sbml/level3/version1/fbc/version1" level="3" version="1" comp:required="true" fbc:required="false">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:fbc="http://www.sbml.org/sbml/level3/version1/fbc/version1" level="3" version="2" comp:required="true" fbc:required="false">
   <model metaid="__main" id="__main">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
@@ -47,12 +47,12 @@
       </constraint>
     </listOfConstraints>
     <listOfReactions>
-      <reaction id="J0" reversible="true" fast="false">
+      <reaction id="J0" reversible="true">
         <listOfReactants>
           <speciesReference species="s1" stoichiometry="1" constant="true"/>
         </listOfReactants>
       </reaction>
-      <reaction id="J1" reversible="true" fast="false">
+      <reaction id="J1" reversible="true">
         <listOfReactants>
           <speciesReference species="s2" stoichiometry="1" constant="true"/>
         </listOfReactants>

--- a/src/test/test-data/fbc/simple_flux_and_objective.xml
+++ b/src/test/test-data/fbc/simple_flux_and_objective.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:fbc="http://www.sbml.org/sbml/level3/version1/fbc/version1" level="3" version="1" comp:required="true" fbc:required="false">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:fbc="http://www.sbml.org/sbml/level3/version1/fbc/version1" level="3" version="2" comp:required="true" fbc:required="false">
   <model metaid="__main" id="__main">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
@@ -19,7 +19,7 @@
       </constraint>
     </listOfConstraints>
     <listOfReactions>
-      <reaction id="J0" reversible="true" fast="false">
+      <reaction id="J0" reversible="true">
         <listOfReactants>
           <speciesReference species="s1" stoichiometry="1" constant="true"/>
         </listOfReactants>

--- a/src/test/test-data/fbc/simple_flux_and_objective2.xml
+++ b/src/test/test-data/fbc/simple_flux_and_objective2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:fbc="http://www.sbml.org/sbml/level3/version1/fbc/version1" level="3" version="1" comp:required="true" fbc:required="false">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:fbc="http://www.sbml.org/sbml/level3/version1/fbc/version1" level="3" version="2" comp:required="true" fbc:required="false">
   <model metaid="__main" id="__main">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
@@ -19,7 +19,7 @@
       </constraint>
     </listOfConstraints>
     <listOfReactions>
-      <reaction id="J0" reversible="true" fast="false">
+      <reaction id="J0" reversible="true">
         <listOfReactants>
           <speciesReference species="s1" stoichiometry="1" constant="true"/>
         </listOfReactants>

--- a/src/test/test-data/fbc/simple_flux_eq_neq.xml
+++ b/src/test/test-data/fbc/simple_flux_eq_neq.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:fbc="http://www.sbml.org/sbml/level3/version1/fbc/version1" level="3" version="1" comp:required="true" fbc:required="false">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:fbc="http://www.sbml.org/sbml/level3/version1/fbc/version1" level="3" version="2" comp:required="true" fbc:required="false">
   <model metaid="__main" id="__main">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
@@ -47,12 +47,12 @@
       </constraint>
     </listOfConstraints>
     <listOfReactions>
-      <reaction id="J0" reversible="true" fast="false">
+      <reaction id="J0" reversible="true">
         <listOfReactants>
           <speciesReference species="s1" stoichiometry="1" constant="true"/>
         </listOfReactants>
       </reaction>
-      <reaction id="J1" reversible="true" fast="false">
+      <reaction id="J1" reversible="true">
         <listOfReactants>
           <speciesReference species="s2" stoichiometry="1" constant="true"/>
         </listOfReactants>

--- a/src/test/test-data/fbc/simple_flux_neg.xml
+++ b/src/test/test-data/fbc/simple_flux_neg.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:fbc="http://www.sbml.org/sbml/level3/version1/fbc/version1" level="3" version="1" comp:required="true" fbc:required="false">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:fbc="http://www.sbml.org/sbml/level3/version1/fbc/version1" level="3" version="2" comp:required="true" fbc:required="false">
   <model metaid="__main" id="__main">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
@@ -19,7 +19,7 @@
       </constraint>
     </listOfConstraints>
     <listOfReactions>
-      <reaction id="J0" reversible="true" fast="false">
+      <reaction id="J0" reversible="true">
         <listOfReactants>
           <speciesReference species="s1" stoichiometry="1" constant="true"/>
         </listOfReactants>

--- a/src/test/test-data/fbc/simple_objective.xml
+++ b/src/test/test-data/fbc/simple_objective.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:fbc="http://www.sbml.org/sbml/level3/version1/fbc/version1" level="3" version="1" comp:required="true" fbc:required="false">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:fbc="http://www.sbml.org/sbml/level3/version1/fbc/version1" level="3" version="2" comp:required="true" fbc:required="false">
   <model metaid="__main" id="__main">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
@@ -8,7 +8,7 @@
       <species id="s1" compartment="default_compartment" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfReactions>
-      <reaction id="J0" reversible="true" fast="false">
+      <reaction id="J0" reversible="true">
         <listOfReactants>
           <speciesReference species="s1" stoichiometry="1" constant="true"/>
         </listOfReactants>

--- a/src/test/test-data/fbc/simple_objective2.xml
+++ b/src/test/test-data/fbc/simple_objective2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:fbc="http://www.sbml.org/sbml/level3/version1/fbc/version1" level="3" version="1" comp:required="true" fbc:required="false">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:fbc="http://www.sbml.org/sbml/level3/version1/fbc/version1" level="3" version="2" comp:required="true" fbc:required="false">
   <model metaid="__main" id="__main">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
@@ -8,7 +8,7 @@
       <species id="s1" compartment="default_compartment" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfReactions>
-      <reaction id="J0" reversible="true" fast="false">
+      <reaction id="J0" reversible="true">
         <listOfReactants>
           <speciesReference species="s1" stoichiometry="1" constant="true"/>
         </listOfReactants>

--- a/src/test/test-data/fbc/simple_objective3.xml
+++ b/src/test/test-data/fbc/simple_objective3.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:fbc="http://www.sbml.org/sbml/level3/version1/fbc/version1" level="3" version="1" comp:required="true" fbc:required="false">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:fbc="http://www.sbml.org/sbml/level3/version1/fbc/version1" level="3" version="2" comp:required="true" fbc:required="false">
   <model metaid="__main" id="__main">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
@@ -8,7 +8,7 @@
       <species id="s1" compartment="default_compartment" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfReactions>
-      <reaction id="J0" reversible="true" fast="false">
+      <reaction id="J0" reversible="true">
         <listOfReactants>
           <speciesReference species="s1" stoichiometry="1" constant="true"/>
         </listOfReactants>

--- a/src/test/test-data/fbc/simple_objective4.xml
+++ b/src/test/test-data/fbc/simple_objective4.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:fbc="http://www.sbml.org/sbml/level3/version1/fbc/version1" level="3" version="1" comp:required="true" fbc:required="false">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:fbc="http://www.sbml.org/sbml/level3/version1/fbc/version1" level="3" version="2" comp:required="true" fbc:required="false">
   <model metaid="__main" id="__main">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
@@ -8,7 +8,7 @@
       <species id="s1" compartment="default_compartment" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfReactions>
-      <reaction id="J0" reversible="true" fast="false">
+      <reaction id="J0" reversible="true">
         <listOfReactants>
           <speciesReference species="s1" stoichiometry="1" constant="true"/>
         </listOfReactants>

--- a/src/test/test-data/fbc/simple_objective5.xml
+++ b/src/test/test-data/fbc/simple_objective5.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:fbc="http://www.sbml.org/sbml/level3/version1/fbc/version1" level="3" version="1" comp:required="true" fbc:required="false">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:fbc="http://www.sbml.org/sbml/level3/version1/fbc/version1" level="3" version="2" comp:required="true" fbc:required="false">
   <model metaid="__main" id="__main">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
@@ -8,7 +8,7 @@
       <species id="s1" compartment="default_compartment" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfReactions>
-      <reaction id="J0" reversible="true" fast="false">
+      <reaction id="J0" reversible="true">
         <listOfReactants>
           <speciesReference species="s1" stoichiometry="1" constant="true"/>
         </listOfReactants>

--- a/src/test/test-data/fbc/two_sided_flux.xml
+++ b/src/test/test-data/fbc/two_sided_flux.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:fbc="http://www.sbml.org/sbml/level3/version1/fbc/version1" level="3" version="1" comp:required="true" fbc:required="false">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:fbc="http://www.sbml.org/sbml/level3/version1/fbc/version1" level="3" version="2" comp:required="true" fbc:required="false">
   <model metaid="__main" id="__main">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
@@ -20,7 +20,7 @@
       </constraint>
     </listOfConstraints>
     <listOfReactions>
-      <reaction id="J0" reversible="true" fast="false">
+      <reaction id="J0" reversible="true">
         <listOfReactants>
           <speciesReference species="s1" stoichiometry="1" constant="true"/>
         </listOfReactants>

--- a/src/test/test-data/fbc/two_sided_flux_complete.xml
+++ b/src/test/test-data/fbc/two_sided_flux_complete.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:fbc="http://www.sbml.org/sbml/level3/version1/fbc/version1" level="3" version="1" comp:required="true" fbc:required="false">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:fbc="http://www.sbml.org/sbml/level3/version1/fbc/version1" level="3" version="2" comp:required="true" fbc:required="false">
   <model metaid="__main" id="__main">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
@@ -120,37 +120,37 @@
       </constraint>
     </listOfConstraints>
     <listOfReactions>
-      <reaction id="J0" reversible="true" fast="false">
+      <reaction id="J0" reversible="true">
         <listOfReactants>
           <speciesReference species="s1" stoichiometry="1" constant="true"/>
         </listOfReactants>
       </reaction>
-      <reaction id="J1" reversible="true" fast="false">
+      <reaction id="J1" reversible="true">
         <listOfReactants>
           <speciesReference species="s2" stoichiometry="1" constant="true"/>
         </listOfReactants>
       </reaction>
-      <reaction id="J2" reversible="true" fast="false">
+      <reaction id="J2" reversible="true">
         <listOfReactants>
           <speciesReference species="s3" stoichiometry="1" constant="true"/>
         </listOfReactants>
       </reaction>
-      <reaction id="J3" reversible="true" fast="false">
+      <reaction id="J3" reversible="true">
         <listOfProducts>
           <speciesReference species="s1" stoichiometry="1" constant="true"/>
         </listOfProducts>
       </reaction>
-      <reaction id="J4" reversible="true" fast="false">
+      <reaction id="J4" reversible="true">
         <listOfProducts>
           <speciesReference species="s2" stoichiometry="1" constant="true"/>
         </listOfProducts>
       </reaction>
-      <reaction id="J5" reversible="true" fast="false">
+      <reaction id="J5" reversible="true">
         <listOfProducts>
           <speciesReference species="s3" stoichiometry="1" constant="true"/>
         </listOfProducts>
       </reaction>
-      <reaction id="J6" reversible="true" fast="false">
+      <reaction id="J6" reversible="true">
         <listOfReactants>
           <speciesReference species="s1" stoichiometry="1" constant="true"/>
         </listOfReactants>
@@ -158,7 +158,7 @@
           <speciesReference species="s2" stoichiometry="1" constant="true"/>
         </listOfProducts>
       </reaction>
-      <reaction id="J7" reversible="true" fast="false">
+      <reaction id="J7" reversible="true">
         <listOfReactants>
           <speciesReference species="s2" stoichiometry="1" constant="true"/>
         </listOfReactants>

--- a/src/test/test-data/fixname_test.xml
+++ b/src/test/test-data/fixname_test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.8.0 on 2015-10-22 11:45 with libSBML version 5.11.9. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar" id="bar" name="bar">
     <listOfCompartments>
       <compartment id="e1" spatialDimensions="3" constant="false">

--- a/src/test/test-data/from-libsbml/CompTest.xml
+++ b/src/test/test-data/from-libsbml/CompTest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="iBioSim1" id="CompTest">
     <listOfFunctionDefinitions>
       <functionDefinition id="neighborQuantityLeft" name="neighborQuantityLeft">
@@ -290,7 +290,7 @@
         </constraint>
       </listOfConstraints>
       <listOfReactions>
-        <reaction metaid="CompModel__iBioSim4" id="R1" reversible="false" fast="false" compartment="Cell">
+        <reaction metaid="CompModel__iBioSim4" id="R1" reversible="false" compartment="Cell">
           <listOfReactants>
             <speciesReference species="S1" stoichiometry="1" constant="true"/>
           </listOfReactants>
@@ -310,7 +310,7 @@
             </listOfLocalParameters>
           </kineticLaw>
         </reaction>
-        <reaction metaid="CompModel__iBioSim5" id="R3" reversible="false" fast="false" compartment="Cell">
+        <reaction metaid="CompModel__iBioSim5" id="R3" reversible="false" compartment="Cell">
           <listOfReactants>
             <speciesReference species="S2" stoichiometry="1" constant="true"/>
           </listOfReactants>

--- a/src/test/test-data/from-libsbml/CompTest_flat.xml
+++ b/src/test/test-data/from-libsbml/CompTest_flat.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" level="3" version="1">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2">
   <model metaid="CompTest" id="CompTest">
     <listOfFunctionDefinitions>
       <functionDefinition id="f">
@@ -171,7 +171,7 @@
       </constraint>
     </listOfConstraints>
     <listOfReactions>
-      <reaction id="C1__R1" reversible="false" fast="false" compartment="Cell">
+      <reaction id="C1__R1" reversible="false" compartment="Cell">
         <listOfReactants>
           <speciesReference species="S2" stoichiometry="1" constant="true"/>
         </listOfReactants>
@@ -188,7 +188,7 @@
           </math>
         </kineticLaw>
       </reaction>
-      <reaction id="C1__R3" reversible="false" fast="false" compartment="Cell">
+      <reaction id="C1__R3" reversible="false" compartment="Cell">
         <listOfReactants>
           <speciesReference species="S1" stoichiometry="1" constant="true"/>
         </listOfReactants>

--- a/src/test/test-data/from-libsbml/QTPop.xml
+++ b/src/test/test-data/from-libsbml/QTPop.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="QTPop" id="QTPop" name="QTPop">
     <listOfFunctionDefinitions>
       <functionDefinition id="get2DArrayElement" name="get2DArrayElement">
@@ -65,7 +65,7 @@
       <parameter id="QuorumTrigger_size" value="16" constant="false"/>
     </listOfParameters>
     <listOfReactions>
-      <reaction id="Degradation_LuxI" reversible="false" fast="false" compartment="default">
+      <reaction id="Degradation_LuxI" reversible="false" compartment="default">
         <annotation><custom xmlns="http://custom/namespace">Type=Grid</custom></annotation>
         <listOfReactants>
           <speciesReference species="LuxI" stoichiometry="1" constant="false"/>
@@ -98,7 +98,7 @@
           </listOfLocalParameters>
         </kineticLaw>
       </reaction>
-      <reaction id="Diffusion_LuxI_Above" reversible="true" fast="false" compartment="default">
+      <reaction id="Diffusion_LuxI_Above" reversible="true" compartment="default">
         <annotation><custom xmlns="http://custom/namespace">Type=Grid</custom></annotation>
         <listOfReactants>
           <speciesReference species="LuxI" stoichiometry="1" constant="false"/>
@@ -155,7 +155,7 @@
           </listOfLocalParameters>
         </kineticLaw>
       </reaction>
-      <reaction id="Diffusion_LuxI_Below" reversible="true" fast="false" compartment="default">
+      <reaction id="Diffusion_LuxI_Below" reversible="true" compartment="default">
         <annotation><custom xmlns="http://custom/namespace">Type=Grid</custom></annotation>
         <listOfReactants>
           <speciesReference species="LuxI" stoichiometry="1" constant="false"/>
@@ -212,7 +212,7 @@
           </listOfLocalParameters>
         </kineticLaw>
       </reaction>
-      <reaction id="Diffusion_LuxI_Left" reversible="true" fast="false" compartment="default">
+      <reaction id="Diffusion_LuxI_Left" reversible="true" compartment="default">
         <annotation><custom xmlns="http://custom/namespace">Type=Grid</custom></annotation>
         <listOfReactants>
           <speciesReference species="LuxI" stoichiometry="1" constant="false"/>
@@ -269,7 +269,7 @@
           </listOfLocalParameters>
         </kineticLaw>
       </reaction>
-      <reaction id="Diffusion_LuxI_Right" reversible="true" fast="false" compartment="default">
+      <reaction id="Diffusion_LuxI_Right" reversible="true" compartment="default">
         <annotation><custom xmlns="http://custom/namespace">Type=Grid</custom></annotation>
         <listOfReactants>
           <speciesReference species="LuxI" stoichiometry="1" constant="false"/>
@@ -326,7 +326,7 @@
           </listOfLocalParameters>
         </kineticLaw>
       </reaction>
-      <reaction id="MembraneDiffusion_LuxI" reversible="true" fast="false" compartment="default">
+      <reaction id="MembraneDiffusion_LuxI" reversible="true" compartment="default">
         <annotation><custom xmlns="http://custom/namespace">Type=Grid</custom></annotation>
         <listOfReactants>
           <speciesReference species="LuxI" stoichiometry="1" constant="false"/>

--- a/src/test/test-data/from-libsbml/QTPop_flat.xml
+++ b/src/test/test-data/from-libsbml/QTPop_flat.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" level="3" version="1">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2">
   <model metaid="QTPop" id="QTPop">
     <listOfFunctionDefinitions>
       <functionDefinition id="get2DArrayElement">
@@ -138,7 +138,7 @@
       <parameter id="MembraneDiffusion_LuxI_j" constant="true"/>
     </listOfParameters>
     <listOfReactions>
-      <reaction id="GRID__QuorumTrigger__Production_P1" reversible="false" fast="false" compartment="GRID__QuorumTrigger__default">
+      <reaction id="GRID__QuorumTrigger__Production_P1" reversible="false" compartment="GRID__QuorumTrigger__default">
         <listOfProducts>
           <speciesReference species="GRID__QuorumTrigger__LuxR" stoichiometry="10" constant="true"/>
         </listOfProducts>
@@ -229,7 +229,7 @@
           </math>
         </kineticLaw>
       </reaction>
-      <reaction id="GRID__QuorumTrigger__Complex_Complex" reversible="true" fast="false" compartment="GRID__QuorumTrigger__default">
+      <reaction id="GRID__QuorumTrigger__Complex_Complex" reversible="true" compartment="GRID__QuorumTrigger__default">
         <listOfReactants>
           <speciesReference species="GRID__QuorumTrigger__LuxR" stoichiometry="2" constant="true"/>
           <speciesReference species="GRID__QuorumTrigger__LuxI" stoichiometry="2" constant="true"/>
@@ -264,7 +264,7 @@
           </math>
         </kineticLaw>
       </reaction>
-      <reaction id="GRID__QuorumTrigger__Production_P5" reversible="false" fast="false" compartment="GRID__QuorumTrigger__default">
+      <reaction id="GRID__QuorumTrigger__Production_P5" reversible="false" compartment="GRID__QuorumTrigger__default">
         <listOfProducts>
           <speciesReference species="GRID__QuorumTrigger__GFP" stoichiometry="10" constant="true"/>
           <speciesReference species="GRID__QuorumTrigger__LuxI" stoichiometry="10" constant="true"/>
@@ -357,7 +357,7 @@
           </math>
         </kineticLaw>
       </reaction>
-      <reaction id="GRID__QuorumTrigger__Degradation_GFP" reversible="false" fast="false" compartment="GRID__QuorumTrigger__default">
+      <reaction id="GRID__QuorumTrigger__Degradation_GFP" reversible="false" compartment="GRID__QuorumTrigger__default">
         <listOfReactants>
           <speciesReference species="GRID__QuorumTrigger__GFP" stoichiometry="1" constant="true"/>
         </listOfReactants>
@@ -371,7 +371,7 @@
           </math>
         </kineticLaw>
       </reaction>
-      <reaction id="GRID__QuorumTrigger__Degradation_LuxI" reversible="false" fast="false" compartment="GRID__QuorumTrigger__default">
+      <reaction id="GRID__QuorumTrigger__Degradation_LuxI" reversible="false" compartment="GRID__QuorumTrigger__default">
         <listOfReactants>
           <speciesReference species="GRID__QuorumTrigger__LuxI" stoichiometry="1" constant="true"/>
         </listOfReactants>
@@ -385,7 +385,7 @@
           </math>
         </kineticLaw>
       </reaction>
-      <reaction id="GRID__QuorumTrigger__Degradation_Complex" reversible="false" fast="false" compartment="GRID__QuorumTrigger__default">
+      <reaction id="GRID__QuorumTrigger__Degradation_Complex" reversible="false" compartment="GRID__QuorumTrigger__default">
         <listOfReactants>
           <speciesReference species="GRID__QuorumTrigger__Complex" stoichiometry="1" constant="true"/>
         </listOfReactants>
@@ -399,7 +399,7 @@
           </math>
         </kineticLaw>
       </reaction>
-      <reaction id="GRID__QuorumTrigger__Degradation_LuxR" reversible="false" fast="false" compartment="GRID__QuorumTrigger__default">
+      <reaction id="GRID__QuorumTrigger__Degradation_LuxR" reversible="false" compartment="GRID__QuorumTrigger__default">
         <listOfReactants>
           <speciesReference species="GRID__QuorumTrigger__LuxR" stoichiometry="1" constant="true"/>
         </listOfReactants>
@@ -413,7 +413,7 @@
           </math>
         </kineticLaw>
       </reaction>
-      <reaction id="GRID__QuorumTrigger__MembraneDiffusion_LuxI" reversible="true" fast="false" compartment="GRID__QuorumTrigger__default">
+      <reaction id="GRID__QuorumTrigger__MembraneDiffusion_LuxI" reversible="true" compartment="GRID__QuorumTrigger__default">
         <listOfReactants>
           <speciesReference species="GRID__QuorumTrigger__LuxI" stoichiometry="1" constant="true"/>
         </listOfReactants>
@@ -431,7 +431,7 @@
           </math>
         </kineticLaw>
       </reaction>
-      <reaction id="Degradation_LuxI" reversible="false" fast="false" compartment="default">
+      <reaction id="Degradation_LuxI" reversible="false" compartment="default">
         <listOfReactants>
           <speciesReference species="LuxI" stoichiometry="1" constant="true"/>
         </listOfReactants>
@@ -450,7 +450,7 @@
           </math>
         </kineticLaw>
       </reaction>
-      <reaction id="Diffusion_LuxI_Above" reversible="true" fast="false" compartment="default">
+      <reaction id="Diffusion_LuxI_Above" reversible="true" compartment="default">
         <listOfReactants>
           <speciesReference species="LuxI" stoichiometry="1" constant="true"/>
         </listOfReactants>
@@ -493,7 +493,7 @@
           </math>
         </kineticLaw>
       </reaction>
-      <reaction id="Diffusion_LuxI_Below" reversible="true" fast="false" compartment="default">
+      <reaction id="Diffusion_LuxI_Below" reversible="true" compartment="default">
         <listOfReactants>
           <speciesReference species="LuxI" stoichiometry="1" constant="true"/>
         </listOfReactants>
@@ -536,7 +536,7 @@
           </math>
         </kineticLaw>
       </reaction>
-      <reaction id="Diffusion_LuxI_Left" reversible="true" fast="false" compartment="default">
+      <reaction id="Diffusion_LuxI_Left" reversible="true" compartment="default">
         <listOfReactants>
           <speciesReference species="LuxI" stoichiometry="1" constant="true"/>
         </listOfReactants>
@@ -579,7 +579,7 @@
           </math>
         </kineticLaw>
       </reaction>
-      <reaction id="Diffusion_LuxI_Right" reversible="true" fast="false" compartment="default">
+      <reaction id="Diffusion_LuxI_Right" reversible="true" compartment="default">
         <listOfReactants>
           <speciesReference species="LuxI" stoichiometry="1" constant="true"/>
         </listOfReactants>
@@ -622,7 +622,7 @@
           </math>
         </kineticLaw>
       </reaction>
-      <reaction id="MembraneDiffusion_LuxI" reversible="true" fast="false" compartment="default">
+      <reaction id="MembraneDiffusion_LuxI" reversible="true" compartment="default">
         <listOfReactants>
           <speciesReference species="LuxI" stoichiometry="1" constant="true"/>
         </listOfReactants>

--- a/src/test/test-data/from-libsbml/QuorumTrigger.xml
+++ b/src/test/test-data/from-libsbml/QuorumTrigger.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="QuorumTrigger" id="QuorumTrigger" name="QuorumTrigger">
     <listOfCompartments>
       <compartment id="default" spatialDimensions="3" size="1" constant="true">
@@ -54,7 +54,7 @@
       <parameter id="kecdiff" name="Extracellular diffusion rate" value="1" constant="true"/>
     </listOfParameters>
     <listOfReactions>
-      <reaction id="Production_P1" reversible="false" fast="false" compartment="default">
+      <reaction id="Production_P1" reversible="false" compartment="default">
         <annotation><custom xmlns="http://custom/namespace">Production</custom></annotation>
         <listOfProducts>
           <speciesReference species="LuxR" stoichiometry="10" constant="true"/>
@@ -150,7 +150,7 @@
           </math>
         </kineticLaw>
       </reaction>
-      <reaction id="Complex_Complex" reversible="true" fast="false" compartment="default">
+      <reaction id="Complex_Complex" reversible="true" compartment="default">
         <annotation><custom xmlns="http://custom/namespace">Complex</custom></annotation>
         <listOfReactants>
           <speciesReference species="LuxR" stoichiometry="2" constant="true"/>
@@ -186,7 +186,7 @@
           </math>
         </kineticLaw>
       </reaction>
-      <reaction id="Production_P5" reversible="false" fast="false" compartment="default">
+      <reaction id="Production_P5" reversible="false" compartment="default">
         <annotation><custom xmlns="http://custom/namespace">Production</custom></annotation>
         <listOfProducts>
           <speciesReference species="GFP" stoichiometry="10" constant="true"/>
@@ -284,7 +284,7 @@
           </math>
         </kineticLaw>
       </reaction>
-      <reaction id="Degradation_GFP" reversible="false" fast="false" compartment="default">
+      <reaction id="Degradation_GFP" reversible="false" compartment="default">
         <annotation><custom xmlns="http://custom/namespace">Degradation</custom></annotation>
         <listOfReactants>
           <speciesReference species="GFP" stoichiometry="1" constant="true"/>
@@ -299,7 +299,7 @@
           </math>
         </kineticLaw>
       </reaction>
-      <reaction id="Degradation_LuxI" reversible="false" fast="false" compartment="default">
+      <reaction id="Degradation_LuxI" reversible="false" compartment="default">
         <annotation><custom xmlns="http://custom/namespace">Degradation</custom></annotation>
         <listOfReactants>
           <speciesReference species="LuxI" stoichiometry="1" constant="true"/>
@@ -314,7 +314,7 @@
           </math>
         </kineticLaw>
       </reaction>
-      <reaction id="Degradation_Complex" reversible="false" fast="false" compartment="default">
+      <reaction id="Degradation_Complex" reversible="false" compartment="default">
         <annotation><custom xmlns="http://custom/namespace">Degradation</custom></annotation>
         <listOfReactants>
           <speciesReference species="Complex" stoichiometry="1" constant="true"/>
@@ -329,7 +329,7 @@
           </math>
         </kineticLaw>
       </reaction>
-      <reaction id="Degradation_LuxR" reversible="false" fast="false" compartment="default">
+      <reaction id="Degradation_LuxR" reversible="false" compartment="default">
         <annotation><custom xmlns="http://custom/namespace">Degradation</custom></annotation>
         <listOfReactants>
           <speciesReference species="LuxR" stoichiometry="1" constant="true"/>
@@ -344,7 +344,7 @@
           </math>
         </kineticLaw>
       </reaction>
-      <reaction id="MembraneDiffusion_LuxI" reversible="true" fast="false" compartment="default">
+      <reaction id="MembraneDiffusion_LuxI" reversible="true" compartment="default">
         <annotation><custom xmlns="http://custom/namespace">Diffusion</custom></annotation>
         <listOfReactants>
           <speciesReference species="LuxI" stoichiometry="1" constant="true"/>

--- a/src/test/test-data/from-libsbml/aggregate.xml
+++ b/src/test/test-data/from-libsbml/aggregate.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model id="aggregate" name="aggregate">
     <comp:listOfSubmodels>
       <comp:submodel comp:id="submod1" comp:modelRef="enzyme"/>
@@ -18,7 +18,7 @@
         <species id="ES" compartment="comp" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
       </listOfSpecies>
       <listOfReactions>
-        <reaction id="J0" reversible="true" fast="false">
+        <reaction id="J0" reversible="true">
           <listOfReactants>
             <speciesReference species="S" stoichiometry="1" constant="true"/>
             <speciesReference species="E" stoichiometry="1" constant="true"/>
@@ -27,7 +27,7 @@
             <speciesReference species="ES" stoichiometry="1" constant="true"/>
           </listOfProducts>
         </reaction>
-        <reaction id="J1" reversible="true" fast="false">
+        <reaction id="J1" reversible="true">
           <listOfReactants>
             <speciesReference species="ES" stoichiometry="1" constant="true"/>
           </listOfReactants>

--- a/src/test/test-data/from-libsbml/complexified.xml
+++ b/src/test/test-data/from-libsbml/complexified.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="complexified" id="complexified" name="complexified">
     <listOfCompartments>
       <compartment id="comp" spatialDimensions="3" size="1" constant="true">
@@ -42,7 +42,7 @@
         <species id="D" compartment="comp" initialConcentration="10" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
       </listOfSpecies>
       <listOfReactions>
-        <reaction id="J0" reversible="true" fast="false">
+        <reaction id="J0" reversible="true">
           <listOfReactants>
             <speciesReference species="S" stoichiometry="1" constant="true"/>
           </listOfReactants>

--- a/src/test/test-data/from-libsbml/complexified2.xml
+++ b/src/test/test-data/from-libsbml/complexified2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="complexified2" id="complexified2" name="complexified2">
     <listOfCompartments>
       <compartment id="comp" spatialDimensions="3" size="1" constant="true">
@@ -34,7 +34,7 @@
       </species>
     </listOfSpecies>
     <listOfReactions>
-      <reaction id="J0" reversible="true" fast="false">
+      <reaction id="J0" reversible="true">
         <listOfReactants>
           <speciesReference species="S" stoichiometry="1" constant="true"/>
           <speciesReference species="E" stoichiometry="1" constant="true"/>
@@ -47,7 +47,7 @@
           <comp:replacedElement comp:portRef="J0_port" comp:submodelRef="A"/>
         </comp:listOfReplacedElements>
       </reaction>
-      <reaction id="J1" reversible="true" fast="false">
+      <reaction id="J1" reversible="true">
         <listOfReactants>
           <speciesReference species="ES" stoichiometry="1" constant="true"/>
         </listOfReactants>
@@ -82,7 +82,7 @@
         <species id="ES" compartment="comp" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
       </listOfSpecies>
       <listOfReactions>
-        <reaction id="J0" reversible="true" fast="false">
+        <reaction id="J0" reversible="true">
           <listOfReactants>
             <speciesReference species="S" stoichiometry="1" constant="true"/>
             <speciesReference species="E" stoichiometry="1" constant="true"/>
@@ -91,7 +91,7 @@
             <speciesReference species="ES" stoichiometry="1" constant="true"/>
           </listOfProducts>
         </reaction>
-        <reaction id="J1" reversible="true" fast="false">
+        <reaction id="J1" reversible="true">
           <listOfReactants>
             <speciesReference species="ES" stoichiometry="1" constant="true"/>
           </listOfReactants>
@@ -117,7 +117,7 @@
         <species id="D" compartment="comp" initialConcentration="10" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
       </listOfSpecies>
       <listOfReactions>
-        <reaction id="J0" reversible="true" fast="false">
+        <reaction id="J0" reversible="true">
           <listOfReactants>
             <speciesReference species="S" stoichiometry="1" constant="true"/>
           </listOfReactants>

--- a/src/test/test-data/from-libsbml/doubleext.xml
+++ b/src/test/test-data/from-libsbml/doubleext.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model name="doc0">
     <comp:listOfSubmodels>
       <comp:submodel comp:id="A" comp:modelRef="EM1"/>

--- a/src/test/test-data/from-libsbml/doubleext2.xml
+++ b/src/test/test-data/from-libsbml/doubleext2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model name="doc0">
     <comp:listOfSubmodels>
       <comp:submodel comp:id="A" comp:modelRef="EM1"/>

--- a/src/test/test-data/from-libsbml/dropports.xml
+++ b/src/test/test-data/from-libsbml/dropports.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model name="doc0">
     <listOfParameters>
       <parameter id="p1" metaid="p1" constant="true"/>

--- a/src/test/test-data/from-libsbml/eg-import-external.xml
+++ b/src/test/test-data/from-libsbml/eg-import-external.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" level="3" version="1"
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2"
       xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" comp:required="true">
   <model name="doc0">
     <listOfCompartments>

--- a/src/test/test-data/from-libsbml/eg-ports.xml
+++ b/src/test/test-data/from-libsbml/eg-ports.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" level="3" version="1"
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2"
       xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" comp:required="true">
   <model metaid="complexified" id="complexified" name="complexified">
     <listOfCompartments>
@@ -47,7 +47,7 @@
                  boundaryCondition="false" constant="false"/>
       </listOfSpecies>
       <listOfReactions>
-        <reaction id="J0" reversible="true" fast="false">
+        <reaction id="J0" reversible="true">
           <listOfReactants>
             <speciesReference species="S" stoichiometry="1" constant="true"/>
           </listOfReactants>

--- a/src/test/test-data/from-libsbml/eg-replacement.xml
+++ b/src/test/test-data/from-libsbml/eg-replacement.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" level="3" version="1"
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2"
       xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" comp:required="true">
   <model metaid="complexified" id="complexified" name="complexified">
     <listOfCompartments>
@@ -27,7 +27,7 @@
       </species>
     </listOfSpecies>
     <listOfReactions>
-      <reaction id="J0" reversible="true" fast="false">
+      <reaction id="J0" reversible="true">
         <listOfReactants>
           <speciesReference species="S" stoichiometry="1" constant="true"/>
         </listOfReactants>
@@ -36,7 +36,7 @@
         </comp:listOfReplacedElements>
         <comp:replacedBy comp:portRef="J0_port" comp:submodelRef="A"/>
       </reaction>
-      <reaction id="J1" reversible="true" fast="false">
+      <reaction id="J1" reversible="true">
         <listOfProducts>
           <speciesReference species="D" stoichiometry="1" constant="true"/>
         </listOfProducts>
@@ -71,7 +71,7 @@
                          boundaryCondition="false" constant="false"/>
       </listOfSpecies>
       <listOfReactions>
-        <reaction id="J0" reversible="true" fast="false">
+        <reaction id="J0" reversible="true">
           <listOfReactants>
             <speciesReference species="S" stoichiometry="1" constant="true"/>
             <speciesReference species="E" stoichiometry="1" constant="true"/>
@@ -80,7 +80,7 @@
             <speciesReference species="ES" stoichiometry="1" constant="true"/>
           </listOfProducts>
         </reaction>
-        <reaction id="J1" reversible="true" fast="false">
+        <reaction id="J1" reversible="true">
           <listOfReactants>
             <speciesReference species="ES" stoichiometry="1" constant="true"/>
           </listOfReactants>
@@ -108,7 +108,7 @@
                         boundaryCondition="false" constant="false"/>
       </listOfSpecies>
       <listOfReactions>
-        <reaction id="J0" reversible="true" fast="false">
+        <reaction id="J0" reversible="true">
           <listOfReactants>
             <speciesReference species="S" stoichiometry="1" constant="true"/>
           </listOfReactants>

--- a/src/test/test-data/from-libsbml/eg-simple-aggregate.xml
+++ b/src/test/test-data/from-libsbml/eg-simple-aggregate.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" level="3" version="1"
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2"
       xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" comp:required="true">
 
   <model metaid="aggregate" id="aggregate" name="aggregate">
@@ -24,7 +24,7 @@
                          boundaryCondition="false" constant="false"/>
       </listOfSpecies>
       <listOfReactions>
-        <reaction id="J0" reversible="true" fast="false">
+        <reaction id="J0" reversible="true">
           <listOfReactants>
             <speciesReference species="S" stoichiometry="1" constant="true"/>
             <speciesReference species="E" stoichiometry="1" constant="true"/>
@@ -33,7 +33,7 @@
             <speciesReference species="ES" stoichiometry="1" constant="true"/>
           </listOfProducts>
         </reaction>
-        <reaction id="J1" reversible="true" fast="false">
+        <reaction id="J1" reversible="true">
           <listOfReactants>
             <speciesReference species="ES" stoichiometry="1" constant="true"/>
           </listOfReactants>

--- a/src/test/test-data/from-libsbml/enzyme_identical.xml
+++ b/src/test/test-data/from-libsbml/enzyme_identical.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model name="doc0">
     <listOfCompartments>
       <compartment id="comp" spatialDimensions="3" size="1" constant="true">

--- a/src/test/test-data/from-libsbml/enzyme_model.xml
+++ b/src/test/test-data/from-libsbml/enzyme_model.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="aggregate" id="aggregate" name="aggregate">
     <comp:listOfSubmodels>
       <comp:submodel comp:id="submod1" comp:modelRef="enzyme"/>
@@ -18,7 +18,7 @@
         <species id="ES" compartment="comp" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
       </listOfSpecies>
       <listOfReactions>
-        <reaction id="J0" reversible="true" fast="false">
+        <reaction id="J0" reversible="true">
           <listOfReactants>
             <speciesReference species="S" stoichiometry="1" constant="true"/>
             <speciesReference species="E" stoichiometry="1" constant="true"/>
@@ -27,7 +27,7 @@
             <speciesReference species="ES" stoichiometry="1" constant="true"/>
           </listOfProducts>
         </reaction>
-        <reaction id="J1" reversible="true" fast="false">
+        <reaction id="J1" reversible="true">
           <listOfReactants>
             <speciesReference species="ES" stoichiometry="1" constant="true"/>
           </listOfReactants>

--- a/src/test/test-data/from-libsbml/exchangetest.xml
+++ b/src/test/test-data/from-libsbml/exchangetest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" level="3" version="1">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2">
   <model metaid="testmod" id="testmod">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
@@ -48,7 +48,7 @@
       </assignmentRule>
     </listOfRules>
     <listOfReactions>
-      <reaction id="A___J0" reversible="true" fast="false">
+      <reaction id="A___J0" reversible="true">
         <listOfReactants>
           <speciesReference species="A__S1" stoichiometry="1" constant="true"/>
         </listOfReactants>

--- a/src/test/test-data/from-libsbml/exchangetest_flat.xml
+++ b/src/test/test-data/from-libsbml/exchangetest_flat.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" level="3" version="1">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2">
   <model metaid="testmod" id="testmod">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
@@ -48,7 +48,7 @@
       </assignmentRule>
     </listOfRules>
     <listOfReactions>
-      <reaction id="A___J0" reversible="true" fast="false">
+      <reaction id="A___J0" reversible="true">
         <listOfReactants>
           <speciesReference species="A__S1" stoichiometry="1" constant="true"/>
         </listOfReactants>

--- a/src/test/test-data/from-libsbml/ext_in_subdir.xml
+++ b/src/test/test-data/from-libsbml/ext_in_subdir.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model name="doc0">
     <comp:listOfSubmodels>
       <comp:submodel comp:id="A" comp:modelRef="EM1"/>

--- a/src/test/test-data/from-libsbml/replace_implied_deletion.xml
+++ b/src/test/test-data/from-libsbml/replace_implied_deletion.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.4 with libSBML version 5.8.0. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar" id="bar" name="bar">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
@@ -9,7 +9,7 @@
       <species id="y" initialAmount="1" compartment="default_compartment" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfReactions>
-      <reaction id="J1" reversible="true" fast="false">
+      <reaction id="J1" reversible="true">
         <listOfProducts>
           <speciesReference id="y_stoich" species="y" stoichiometry="1" constant="false">
             <comp:listOfReplacedElements>
@@ -36,7 +36,7 @@
         <species id="x" initialAmount="1" compartment="default_compartment" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
       </listOfSpecies>
       <listOfReactions>
-        <reaction id="J0" reversible="true" fast="false">
+        <reaction id="J0" reversible="true">
           <listOfReactants>
             <speciesReference id="x_stoich" species="x" stoichiometry="1" constant="false"/>
           </listOfReactants>

--- a/src/test/test-data/from-libsbml/replace_implied_deletion2.xml
+++ b/src/test/test-data/from-libsbml/replace_implied_deletion2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.4 with libSBML version 5.8.0. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar" id="bar" name="bar">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
@@ -9,7 +9,7 @@
       <species id="y" initialAmount="1" compartment="default_compartment" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfReactions>
-      <reaction id="J1" reversible="true" fast="false">
+      <reaction id="J1" reversible="true">
         <listOfProducts>
           <speciesReference id="y_stoich" species="y" stoichiometry="1" constant="false">
             <comp:listOfReplacedElements>
@@ -47,7 +47,7 @@
         </initialAssignment>
       </listOfInitialAssignments>
       <listOfReactions>
-        <reaction id="J0" reversible="true" fast="false">
+        <reaction id="J0" reversible="true">
           <listOfReactants>
             <speciesReference id="x_stoich" species="x" stoichiometry="1" constant="false"/>
           </listOfReactants>

--- a/src/test/test-data/from-libsbml/replace_rule.xml
+++ b/src/test/test-data/from-libsbml/replace_rule.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="iBioSim1" id="CompTest3_antimony_roundtrip" name="CompTest3_antimony_roundtrip">
     <listOfCompartments>
       <compartment id="Cell" spatialDimensions="3" size="1" constant="true"/>

--- a/src/test/test-data/from-libsbml/replace_rules_and_constraints.xml
+++ b/src/test/test-data/from-libsbml/replace_rules_and_constraints.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="iBioSim1" id="CompTest3_antimony_roundtrip" name="CompTest">
     <listOfCompartments>
       <compartment id="Cell" spatialDimensions="3" size="1" constant="true">
@@ -153,7 +153,7 @@
         </constraint>
       </listOfConstraints>
       <listOfReactions>
-        <reaction metaid="CompModel__iBioSim4" id="R1" reversible="false" fast="false">
+        <reaction metaid="CompModel__iBioSim4" id="R1" reversible="false">
           <listOfReactants>
             <speciesReference species="S1" stoichiometry="1" constant="true"/>
           </listOfReactants>
@@ -170,7 +170,7 @@
             </math>
           </kineticLaw>
         </reaction>
-        <reaction metaid="CompModel__iBioSim5" id="R3" reversible="false" fast="false">
+        <reaction metaid="CompModel__iBioSim5" id="R3" reversible="false">
           <listOfReactants>
             <speciesReference species="S2" stoichiometry="1" constant="true"/>
           </listOfReactants>

--- a/src/test/test-data/from-libsbml/replace_rules_and_constraints_flat.xml
+++ b/src/test/test-data/from-libsbml/replace_rules_and_constraints_flat.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" level="3" version="1">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2">
   <model metaid="CompTest3_antimony_roundtrip" id="CompTest3_antimony_roundtrip" name="CompTest">
     <listOfCompartments>
       <compartment id="Cell" spatialDimensions="3" size="1" constant="true"/>
@@ -88,7 +88,7 @@
       </constraint>
     </listOfConstraints>
     <listOfReactions>
-      <reaction id="C1__R1" reversible="false" fast="false">
+      <reaction id="C1__R1" reversible="false">
         <listOfReactants>
           <speciesReference species="C1__S1" stoichiometry="1" constant="true"/>
         </listOfReactants>
@@ -105,7 +105,7 @@
           </math>
         </kineticLaw>
       </reaction>
-      <reaction id="C1__R3" reversible="false" fast="false">
+      <reaction id="C1__R3" reversible="false">
         <listOfReactants>
           <speciesReference species="C1__S2" stoichiometry="1" constant="true"/>
         </listOfReactants>

--- a/src/test/test-data/from-libsbml/subdir/new_aggregate.xml
+++ b/src/test/test-data/from-libsbml/subdir/new_aggregate.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="aggregate" id="aggregate" name="aggregate">
     <comp:listOfSubmodels>
       <comp:submodel comp:id="submod1" comp:modelRef="enzyme"/>
@@ -18,7 +18,7 @@
         <species id="ES" compartment="comp" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
       </listOfSpecies>
       <listOfReactions>
-        <reaction id="J0" reversible="true" fast="false">
+        <reaction id="J0" reversible="true">
           <listOfReactants>
             <speciesReference species="S" stoichiometry="1" constant="true"/>
             <speciesReference species="E" stoichiometry="1" constant="true"/>
@@ -27,7 +27,7 @@
             <speciesReference species="ES" stoichiometry="1" constant="true"/>
           </listOfProducts>
         </reaction>
-        <reaction id="J1" reversible="true" fast="false">
+        <reaction id="J1" reversible="true">
           <listOfReactants>
             <speciesReference species="ES" stoichiometry="1" constant="true"/>
           </listOfReactants>

--- a/src/test/test-data/from-libsbml/test1.xml
+++ b/src/test/test-data/from-libsbml/test1.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model name="doc0">
     <listOfParameters>
       <parameter id="param1" constant="true">

--- a/src/test/test-data/from-libsbml/test10.xml
+++ b/src/test/test-data/from-libsbml/test10.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model name="doc0">
     <listOfCompartments>
       <compartment id="C" spatialDimensions="3" size="10" constant="false">

--- a/src/test/test-data/from-libsbml/test10_flat.xml
+++ b/src/test/test-data/from-libsbml/test10_flat.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" level="3" version="1">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2">
   <model name="doc0">
     <listOfCompartments>
       <compartment id="C" spatialDimensions="3" size="10" constant="false"/>

--- a/src/test/test-data/from-libsbml/test11.xml
+++ b/src/test/test-data/from-libsbml/test11.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model name="doc0">
     <listOfCompartments>
       <compartment id="C" spatialDimensions="3" size="10" constant="false">

--- a/src/test/test-data/from-libsbml/test12.xml
+++ b/src/test/test-data/from-libsbml/test12.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model name="doc0">
     <listOfCompartments>
       <compartment id="C" spatialDimensions="3" size="10" constant="false">

--- a/src/test/test-data/from-libsbml/test13.xml
+++ b/src/test/test-data/from-libsbml/test13.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model name="doc0">
     <listOfCompartments>
       <compartment id="C" spatialDimensions="3" size="10" constant="false">

--- a/src/test/test-data/from-libsbml/test14.xml
+++ b/src/test/test-data/from-libsbml/test14.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model name="doc0">
     <listOfCompartments>
       <compartment id="C" spatialDimensions="3" size="10" constant="false">

--- a/src/test/test-data/from-libsbml/test15.xml
+++ b/src/test/test-data/from-libsbml/test15.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model name="doc0">
     <listOfParameters>
       <parameter id="p2" value="2" constant="false">

--- a/src/test/test-data/from-libsbml/test16.xml
+++ b/src/test/test-data/from-libsbml/test16.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model name="doc0">
     <listOfParameters>
       <parameter id="p2" value="2" constant="false">

--- a/src/test/test-data/from-libsbml/test17.xml
+++ b/src/test/test-data/from-libsbml/test17.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model name="doc0">
     <listOfParameters>
       <parameter id="p8" constant="false">

--- a/src/test/test-data/from-libsbml/test18.xml
+++ b/src/test/test-data/from-libsbml/test18.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model name="doc0">
     <listOfParameters>
       <parameter id="p8" value="8" constant="false">

--- a/src/test/test-data/from-libsbml/test19.xml
+++ b/src/test/test-data/from-libsbml/test19.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model name="doc0">
     <listOfParameters>
       <parameter id="p8" value="8" constant="false">

--- a/src/test/test-data/from-libsbml/test2.xml
+++ b/src/test/test-data/from-libsbml/test2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model name="doc0">
     <listOfParameters>
       <parameter id="param1" value="2.3" constant="true">

--- a/src/test/test-data/from-libsbml/test20.xml
+++ b/src/test/test-data/from-libsbml/test20.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model name="doc0">
     <listOfCompartments>
       <compartment id="C" size="1" constant="true"/>

--- a/src/test/test-data/from-libsbml/test21.xml
+++ b/src/test/test-data/from-libsbml/test21.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model name="doc0">
     <listOfCompartments>
       <compartment id="C8" size="8" constant="false">

--- a/src/test/test-data/from-libsbml/test22.xml
+++ b/src/test/test-data/from-libsbml/test22.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model id="doc0" name="doc0">
     <listOfCompartments>
       <compartment id="C" size="1" constant="true">
@@ -126,7 +126,7 @@
         </constraint>
       </listOfConstraints>
       <listOfReactions>
-        <reaction id="J0" reversible="true" fast="false">
+        <reaction id="J0" reversible="true">
           <listOfProducts>
             <speciesReference species="s1" constant="true"/>
           </listOfProducts>

--- a/src/test/test-data/from-libsbml/test22_flat.xml
+++ b/src/test/test-data/from-libsbml/test22_flat.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" level="3" version="1">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2">
   <model metaid="doc0" id="doc0" name="doc0">
     <listOfCompartments>
       <compartment id="C" spatialDimensions="3" size="1" constant="true"/>
@@ -86,7 +86,7 @@
       </constraint>
     </listOfConstraints>
     <listOfReactions>
-      <reaction id="sub1__J0" reversible="true" fast="false">
+      <reaction id="sub1__J0" reversible="true">
         <listOfProducts>
           <speciesReference species="s1" stoichiometry="1" constant="true"/>
         </listOfProducts>

--- a/src/test/test-data/from-libsbml/test23.xml
+++ b/src/test/test-data/from-libsbml/test23.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model id="doc0" name="doc0">
     <listOfParameters>
       <parameter id="timeconv" value="60" constant="true"/>
@@ -113,7 +113,7 @@
         </constraint>
       </listOfConstraints>
       <listOfReactions>
-        <reaction id="J0" reversible="true" fast="false">
+        <reaction id="J0" reversible="true">
           <listOfProducts>
             <speciesReference species="s1" constant="true"/>
           </listOfProducts>

--- a/src/test/test-data/from-libsbml/test23_flat.xml
+++ b/src/test/test-data/from-libsbml/test23_flat.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" level="3" version="1">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2">
   <model metaid="doc0" id="doc0" name="doc0">
     <listOfCompartments>
       <compartment id="sub1__C" spatialDimensions="3" size="1" constant="true"/>
@@ -87,7 +87,7 @@
       </constraint>
     </listOfConstraints>
     <listOfReactions>
-      <reaction id="sub1__J0" reversible="true" fast="false">
+      <reaction id="sub1__J0" reversible="true">
         <listOfProducts>
           <speciesReference species="sub1__s1" stoichiometry="1" constant="true"/>
         </listOfProducts>

--- a/src/test/test-data/from-libsbml/test24.xml
+++ b/src/test/test-data/from-libsbml/test24.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model id="doc0" name="doc0">
     <listOfParameters>
       <parameter id="extentconv" value="1000" constant="true"/>
@@ -17,7 +17,7 @@
         <species id="s1" compartment="C" initialAmount="1" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
       </listOfSpecies>
       <listOfReactions>
-        <reaction id="J0" reversible="true" fast="false">
+        <reaction id="J0" reversible="true">
           <listOfProducts>
             <speciesReference species="s1" constant="true"/>
           </listOfProducts>

--- a/src/test/test-data/from-libsbml/test24_flat.xml
+++ b/src/test/test-data/from-libsbml/test24_flat.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" level="3" version="1">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2">
   <model metaid="doc0" id="doc0" name="doc0">
     <listOfCompartments>
       <compartment id="sub1__C" spatialDimensions="3" size="1" constant="true"/>
@@ -11,7 +11,7 @@
       <parameter id="extentconv" value="1000" constant="true"/>
     </listOfParameters>
     <listOfReactions>
-      <reaction id="sub1__J0" reversible="true" fast="false">
+      <reaction id="sub1__J0" reversible="true">
         <listOfProducts>
           <speciesReference species="sub1__s1" stoichiometry="1" constant="true"/>
         </listOfProducts>

--- a/src/test/test-data/from-libsbml/test25.xml
+++ b/src/test/test-data/from-libsbml/test25.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model id="doc0" name="doc0">
     <listOfParameters>
       <parameter id="extentconv" value="1000" constant="true"/>
@@ -22,7 +22,7 @@
         <species id="s1" compartment="C" initialAmount="1" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
       </listOfSpecies>
       <listOfReactions>
-        <reaction id="J0" reversible="true" fast="false">
+        <reaction id="J0" reversible="true">
           <listOfProducts>
             <speciesReference species="s1" constant="true"/>
           </listOfProducts>

--- a/src/test/test-data/from-libsbml/test25_flat.xml
+++ b/src/test/test-data/from-libsbml/test25_flat.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" level="3" version="1">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2">
   <model metaid="doc0" id="doc0" name="doc0">
     <listOfCompartments>
       <compartment id="sub1__sub1__C" spatialDimensions="3" size="1" constant="true"/>
@@ -11,7 +11,7 @@
       <parameter id="extentconv" value="1000" constant="true"/>
     </listOfParameters>
     <listOfReactions>
-      <reaction id="sub1__sub1__J0" reversible="true" fast="false">
+      <reaction id="sub1__sub1__J0" reversible="true">
         <listOfProducts>
           <speciesReference species="sub1__sub1__s1" stoichiometry="1" constant="true"/>
         </listOfProducts>

--- a/src/test/test-data/from-libsbml/test26.xml
+++ b/src/test/test-data/from-libsbml/test26.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model name="doc0">
     <listOfParameters>
       <parameter id="timeconv" value="60" constant="true"/>

--- a/src/test/test-data/from-libsbml/test27.xml
+++ b/src/test/test-data/from-libsbml/test27.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model id="doc0" name="doc0">
     <listOfParameters>
       <parameter id="timeconv" value="60" constant="true"/>

--- a/src/test/test-data/from-libsbml/test27_flat.xml
+++ b/src/test/test-data/from-libsbml/test27_flat.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" level="3" version="1">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2">
   <model metaid="doc0" id="doc0" name="doc0">
     <listOfParameters>
       <parameter id="sub1__sub1__t1" constant="false"/>

--- a/src/test/test-data/from-libsbml/test28.xml
+++ b/src/test/test-data/from-libsbml/test28.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model id="doc0" name="doc0">
     <listOfParameters>
       <parameter id="timeconv" value="60" constant="true"/>
@@ -36,7 +36,7 @@
         <species id="s1" compartment="C" initialAmount="1" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
       </listOfSpecies>
       <listOfReactions>
-        <reaction id="J0" reversible="true" fast="false">
+        <reaction id="J0" reversible="true">
           <listOfProducts>
             <speciesReference species="s1" constant="true"/>
           </listOfProducts>

--- a/src/test/test-data/from-libsbml/test28_flat.xml
+++ b/src/test/test-data/from-libsbml/test28_flat.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" level="3" version="1">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2">
   <model metaid="doc0" id="doc0" name="doc0">
     <listOfCompartments>
       <compartment id="sub1__sub1__sub1__C" spatialDimensions="3" size="1" constant="true"/>
@@ -16,7 +16,7 @@
       <parameter id="extentconv" value="10" constant="true"/>
     </listOfParameters>
     <listOfReactions>
-      <reaction id="sub1__sub1__sub1__J0" reversible="true" fast="false">
+      <reaction id="sub1__sub1__sub1__J0" reversible="true">
         <listOfProducts>
           <speciesReference species="sub1__sub1__sub1__s1" stoichiometry="1" constant="true"/>
         </listOfProducts>

--- a/src/test/test-data/from-libsbml/test29.xml
+++ b/src/test/test-data/from-libsbml/test29.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model name="doc0">
     <listOfParameters>
       <parameter id="p8" value="8" constant="false">

--- a/src/test/test-data/from-libsbml/test3.xml
+++ b/src/test/test-data/from-libsbml/test3.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model name="doc0">
     <listOfParameters>
       <parameter id="param1" constant="true">

--- a/src/test/test-data/from-libsbml/test30.xml
+++ b/src/test/test-data/from-libsbml/test30.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model name="doc0">
     <listOfParameters>
       <parameter id="p8" value="8" constant="false">

--- a/src/test/test-data/from-libsbml/test31.xml
+++ b/src/test/test-data/from-libsbml/test31.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model name="doc0">
     <listOfParameters>
       <parameter id="p8" value="8" constant="false">

--- a/src/test/test-data/from-libsbml/test32.xml
+++ b/src/test/test-data/from-libsbml/test32.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.3-beta with libSBML version 5.5.0. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="doc0" id="doc0" name="doc0">
     <listOfParameters>
       <parameter id="conv" value="0.1" constant="true"/>

--- a/src/test/test-data/from-libsbml/test33.xml
+++ b/src/test/test-data/from-libsbml/test33.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.3-beta with libSBML version 5.6.0. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="baz" id="baz" name="baz">
     <listOfParameters>
       <parameter id="z" constant="false">

--- a/src/test/test-data/from-libsbml/test34.xml
+++ b/src/test/test-data/from-libsbml/test34.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model name="doc0">
     <comp:listOfSubmodels>
       <comp:submodel comp:id="sub1" comp:modelRef="moddef1">

--- a/src/test/test-data/from-libsbml/test35.xml
+++ b/src/test/test-data/from-libsbml/test35.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model name="doc0">
     <comp:listOfSubmodels>
       <comp:submodel comp:id="sub1" comp:modelRef="moddef1">

--- a/src/test/test-data/from-libsbml/test36.xml
+++ b/src/test/test-data/from-libsbml/test36.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model name="doc0">
     <comp:listOfSubmodels>
       <comp:submodel comp:id="sub1" comp:modelRef="moddef1">

--- a/src/test/test-data/from-libsbml/test37.xml
+++ b/src/test/test-data/from-libsbml/test37.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model name="doc0">
     <comp:listOfSubmodels>
       <comp:submodel comp:id="sub1" comp:modelRef="moddef1">

--- a/src/test/test-data/from-libsbml/test38.xml
+++ b/src/test/test-data/from-libsbml/test38.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model name="doc0">
     <comp:listOfSubmodels>
       <comp:submodel comp:id="sub1" comp:modelRef="moddef1">

--- a/src/test/test-data/from-libsbml/test39.xml
+++ b/src/test/test-data/from-libsbml/test39.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model id="doc0" name="doc0">
     <comp:listOfSubmodels>
       <comp:submodel comp:id="sub1" comp:modelRef="moddef1">
@@ -21,7 +21,7 @@
         <parameter id="p1" value="100" constant="true"/>
       </listOfParameters>
       <listOfReactions>
-        <reaction id="J0" reversible="true" fast="false">
+        <reaction id="J0" reversible="true">
           <listOfProducts>
             <speciesReference species="s1" constant="true"/>
           </listOfProducts>

--- a/src/test/test-data/from-libsbml/test39_flat.xml
+++ b/src/test/test-data/from-libsbml/test39_flat.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" level="3" version="1">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2">
   <model metaid="doc0" id="doc0" name="doc0">
     <listOfCompartments>
       <compartment id="sub1__C" spatialDimensions="3" size="1" constant="true"/>
@@ -11,7 +11,7 @@
       <parameter id="p1" value="100" constant="true"/>
     </listOfParameters>
     <listOfReactions>
-      <reaction id="sub1__J0" reversible="true" fast="false">
+      <reaction id="sub1__J0" reversible="true">
         <listOfProducts>
           <speciesReference species="sub1__s1" stoichiometry="1" constant="true"/>
         </listOfProducts>

--- a/src/test/test-data/from-libsbml/test4.xml
+++ b/src/test/test-data/from-libsbml/test4.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model name="doc0">
     <listOfParameters>
       <parameter id="param1" value="10.42" constant="true">

--- a/src/test/test-data/from-libsbml/test40.xml
+++ b/src/test/test-data/from-libsbml/test40.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model name="doc0">
     <listOfParameters>
       <parameter metaid="new_p1_metaid" id="new_p1" value="100" constant="true">
@@ -21,7 +21,7 @@
         <species id="s1" compartment="C" initialAmount="0.001" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
       </listOfSpecies>
       <listOfReactions>
-        <reaction id="J0" reversible="true" fast="false">
+        <reaction id="J0" reversible="true">
           <listOfProducts>
             <speciesReference species="s1" constant="true"/>
           </listOfProducts>

--- a/src/test/test-data/from-libsbml/test41.xml
+++ b/src/test/test-data/from-libsbml/test41.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model name="doc0">
     <comp:listOfSubmodels>
       <comp:submodel comp:id="sub1" comp:modelRef="moddef1"/>
@@ -17,7 +17,7 @@
         <parameter metaid="unused_p1" id="p1" value="100" constant="true"/>
       </listOfParameters>
       <listOfReactions>
-        <reaction id="J0" reversible="true" fast="false">
+        <reaction id="J0" reversible="true">
           <listOfProducts>
             <speciesReference species="s1" constant="true"/>
           </listOfProducts>

--- a/src/test/test-data/from-libsbml/test42.xml
+++ b/src/test/test-data/from-libsbml/test42.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model name="doc0">
     <listOfParameters>
       <parameter id="p8" value="8" constant="false">

--- a/src/test/test-data/from-libsbml/test43.xml
+++ b/src/test/test-data/from-libsbml/test43.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model name="doc0">
     <listOfParameters>
       <parameter id="p8" value="8" constant="false">

--- a/src/test/test-data/from-libsbml/test44.xml
+++ b/src/test/test-data/from-libsbml/test44.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model id="doc0" name="doc0">
     <listOfParameters>
       <parameter id="extentconv" value="1000" constant="true"/>
@@ -31,7 +31,7 @@
         </assignmentRule>
       </listOfRules>
       <listOfReactions>
-        <reaction id="J0" reversible="true" fast="false">
+        <reaction id="J0" reversible="true">
           <listOfProducts>
             <speciesReference species="s1" constant="true"/>
           </listOfProducts>

--- a/src/test/test-data/from-libsbml/test44_flat.xml
+++ b/src/test/test-data/from-libsbml/test44_flat.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" level="3" version="1">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2">
   <model metaid="doc0" id="doc0" name="doc0">
     <listOfCompartments>
       <compartment id="sub1__C" spatialDimensions="3" size="1" constant="true"/>
@@ -27,7 +27,7 @@
       </assignmentRule>
     </listOfRules>
     <listOfReactions>
-      <reaction id="sub1__J0" reversible="true" fast="false">
+      <reaction id="sub1__J0" reversible="true">
         <listOfProducts>
           <speciesReference species="sub1__s1" stoichiometry="1" constant="true"/>
         </listOfProducts>

--- a/src/test/test-data/from-libsbml/test45.xml
+++ b/src/test/test-data/from-libsbml/test45.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model id="doc0" name="doc0">
     <listOfParameters>
       <parameter id="timeconv" value="60" constant="true"/>

--- a/src/test/test-data/from-libsbml/test45_flat.xml
+++ b/src/test/test-data/from-libsbml/test45_flat.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" level="3" version="1">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2">
   <model metaid="doc0" id="doc0" name="doc0">
     <listOfParameters>
       <parameter id="t1" value="1" constant="false"/>

--- a/src/test/test-data/from-libsbml/test46.xml
+++ b/src/test/test-data/from-libsbml/test46.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model id="doc0" name="doc0">
     <listOfParameters>
       <parameter id="timeconv" value="60" constant="true"/>
@@ -31,7 +31,7 @@
         </assignmentRule>
       </listOfRules>
       <listOfReactions>
-        <reaction id="J0" reversible="true" fast="false">
+        <reaction id="J0" reversible="true">
           <listOfProducts>
             <speciesReference species="s1" constant="true"/>
           </listOfProducts>

--- a/src/test/test-data/from-libsbml/test46_flat.xml
+++ b/src/test/test-data/from-libsbml/test46_flat.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" level="3" version="1">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2">
   <model metaid="doc0" id="doc0" name="doc0">
     <listOfCompartments>
       <compartment id="sub1__C" spatialDimensions="3" size="1" constant="true"/>
@@ -27,7 +27,7 @@
       </assignmentRule>
     </listOfRules>
     <listOfReactions>
-      <reaction id="sub1__J0" reversible="true" fast="false">
+      <reaction id="sub1__J0" reversible="true">
         <listOfProducts>
           <speciesReference species="sub1__s1" stoichiometry="1" constant="true"/>
         </listOfProducts>

--- a/src/test/test-data/from-libsbml/test47.xml
+++ b/src/test/test-data/from-libsbml/test47.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model id="doc0" name="doc0">
     <listOfParameters>
       <parameter id="extentconv" value="1000" constant="true"/>
@@ -32,7 +32,7 @@
         </assignmentRule>
       </listOfRules>
       <listOfReactions>
-        <reaction id="J0" reversible="true" fast="false">
+        <reaction id="J0" reversible="true">
           <listOfProducts>
             <speciesReference species="s1" constant="true"/>
           </listOfProducts>

--- a/src/test/test-data/from-libsbml/test47_flat.xml
+++ b/src/test/test-data/from-libsbml/test47_flat.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" level="3" version="1">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2">
   <model metaid="doc0" id="doc0" name="doc0">
     <listOfCompartments>
       <compartment id="sub1__C" spatialDimensions="3" size="1" constant="true"/>
@@ -32,7 +32,7 @@
       </assignmentRule>
     </listOfRules>
     <listOfReactions>
-      <reaction id="sub1__J0" reversible="true" fast="false">
+      <reaction id="sub1__J0" reversible="true">
         <listOfProducts>
           <speciesReference species="sub1__s1" stoichiometry="1" constant="true"/>
         </listOfProducts>

--- a/src/test/test-data/from-libsbml/test48.xml
+++ b/src/test/test-data/from-libsbml/test48.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model id="doc0" name="doc0">
     <listOfParameters>
       <parameter id="extentconv" value="1000" constant="true"/>
@@ -32,7 +32,7 @@
         </assignmentRule>
       </listOfRules>
       <listOfReactions>
-        <reaction id="J0" reversible="true" fast="false">
+        <reaction id="J0" reversible="true">
           <listOfProducts>
             <speciesReference species="s1" constant="true"/>
           </listOfProducts>

--- a/src/test/test-data/from-libsbml/test48_flat.xml
+++ b/src/test/test-data/from-libsbml/test48_flat.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" level="3" version="1">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2">
   <model metaid="doc0" id="doc0" name="doc0">
     <listOfCompartments>
       <compartment id="sub1__C" spatialDimensions="3" size="1" constant="true"/>
@@ -32,7 +32,7 @@
       </assignmentRule>
     </listOfRules>
     <listOfReactions>
-      <reaction id="sub1__J0" reversible="true" fast="false">
+      <reaction id="sub1__J0" reversible="true">
         <listOfProducts>
           <speciesReference species="sub1__s1" stoichiometry="1" constant="true"/>
         </listOfProducts>

--- a/src/test/test-data/from-libsbml/test49.xml
+++ b/src/test/test-data/from-libsbml/test49.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model name="doc0">
     <listOfCompartments>
       <compartment id="C" size="1" constant="true"/>
@@ -12,7 +12,7 @@
       <parameter id="timeconv" value="60" constant="true"/>
     </listOfParameters>
     <listOfReactions>
-      <reaction id="J0" reversible="true" fast="false">
+      <reaction id="J0" reversible="true">
         <listOfProducts>
           <speciesReference species="s1" constant="true"/>
         </listOfProducts>
@@ -53,7 +53,7 @@
         </assignmentRule>
       </listOfRules>
       <listOfReactions>
-        <reaction id="J0" reversible="true" fast="false">
+        <reaction id="J0" reversible="true">
           <listOfProducts>
             <speciesReference species="s1" constant="true"/>
           </listOfProducts>

--- a/src/test/test-data/from-libsbml/test5.xml
+++ b/src/test/test-data/from-libsbml/test5.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model name="doc0">
     <listOfParameters>
       <parameter id="param1" value="10.42" constant="true">

--- a/src/test/test-data/from-libsbml/test50.xml
+++ b/src/test/test-data/from-libsbml/test50.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model name="doc0">
     <listOfCompartments>
       <compartment id="C" size="1" constant="true"/>
@@ -13,7 +13,7 @@
       <parameter id="extentpertimeconv" value="16.6666666666667" constant="true"/>
     </listOfParameters>
     <listOfReactions>
-      <reaction id="J0" reversible="true" fast="false">
+      <reaction id="J0" reversible="true">
         <listOfProducts>
           <speciesReference species="s1" constant="true"/>
         </listOfProducts>
@@ -54,7 +54,7 @@
         </assignmentRule>
       </listOfRules>
       <listOfReactions>
-        <reaction id="J0" reversible="true" fast="false">
+        <reaction id="J0" reversible="true">
           <listOfProducts>
             <speciesReference species="s1" constant="true"/>
           </listOfProducts>

--- a/src/test/test-data/from-libsbml/test51.xml
+++ b/src/test/test-data/from-libsbml/test51.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.4 with libSBML version 5.8.0. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="main" id="main" name="main">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true">
@@ -14,7 +14,7 @@
       <species id="y" compartment="default_compartment" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfReactions>
-      <reaction id="J1" reversible="true" fast="false">
+      <reaction id="J1" reversible="true">
         <listOfReactants>
           <speciesReference id="x_stoich" species="x" stoichiometry="1" constant="true">
             <comp:listOfReplacedElements>
@@ -54,7 +54,7 @@
         </initialAssignment>
       </listOfInitialAssignments>
       <listOfReactions>
-        <reaction id="J0" reversible="true" fast="false">
+        <reaction id="J0" reversible="true">
           <listOfReactants>
             <speciesReference id="a_stoich" species="a" stoichiometry="1" constant="true"/>
           </listOfReactants>

--- a/src/test/test-data/from-libsbml/test52.xml
+++ b/src/test/test-data/from-libsbml/test52.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.4 with libSBML version 5.8.0. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="main" id="main" name="main">
     <comp:listOfSubmodels>
       <comp:submodel comp:id="B" comp:modelRef="sub1">
@@ -21,7 +21,7 @@
         <species id="y" compartment="default_compartment" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
       </listOfSpecies>
       <listOfReactions>
-        <reaction id="J0" reversible="true" fast="false">
+        <reaction id="J0" reversible="true">
           <listOfProducts>
             <speciesReference id="y_stoich" species="y" stoichiometry="1" constant="true"/>
           </listOfProducts>

--- a/src/test/test-data/from-libsbml/test53.xml
+++ b/src/test/test-data/from-libsbml/test53.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.4 with libSBML version 5.8.0. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="main" id="main" name="main">
     <comp:listOfSubmodels>
       <comp:submodel comp:id="B" comp:modelRef="sub1">
@@ -22,7 +22,7 @@
         <species id="z" compartment="default_compartment" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
       </listOfSpecies>
       <listOfReactions>
-        <reaction id="J0" reversible="true" fast="false">
+        <reaction id="J0" reversible="true">
           <listOfProducts>
             <speciesReference id="y_stoich" species="y" stoichiometry="1" constant="true"/>
             <speciesReference id="z_stoich" species="z" stoichiometry="1" constant="true"/>

--- a/src/test/test-data/from-libsbml/test54.xml
+++ b/src/test/test-data/from-libsbml/test54.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.4 with libSBML version 5.8.0. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="baz" id="baz">
     <comp:listOfSubmodels>
       <comp:submodel comp:id="B" comp:modelRef="bar">

--- a/src/test/test-data/from-libsbml/test54_flat.xml
+++ b/src/test/test-data/from-libsbml/test54_flat.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" level="3" version="1">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2">
   <model metaid="baz" id="baz"/>
 </sbml>

--- a/src/test/test-data/from-libsbml/test55.xml
+++ b/src/test/test-data/from-libsbml/test55.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.4 with libSBML version 5.8.0. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar" id="bar" name="bar">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true">
@@ -17,7 +17,7 @@
       </species>
     </listOfSpecies>
     <listOfReactions>
-      <reaction id="J1" reversible="true" fast="false">
+      <reaction id="J1" reversible="true">
         <listOfProducts>
           <speciesReference id="y_stoich" species="y" stoichiometry="1" constant="true">
             <comp:listOfReplacedElements>
@@ -43,7 +43,7 @@
         <species id="x" compartment="default_compartment" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
       </listOfSpecies>
       <listOfReactions>
-        <reaction id="J0" reversible="true" fast="false">
+        <reaction id="J0" reversible="true">
           <listOfReactants>
             <speciesReference id="x_stoich" species="x" stoichiometry="1" constant="true"/>
           </listOfReactants>

--- a/src/test/test-data/from-libsbml/test56.xml
+++ b/src/test/test-data/from-libsbml/test56.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.4 with libSBML version 5.8.0. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar" id="bar" name="bar">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true">
@@ -17,7 +17,7 @@
       </species>
     </listOfSpecies>
     <listOfReactions>
-      <reaction id="J1" reversible="true" fast="false">
+      <reaction id="J1" reversible="true">
         <listOfProducts>
           <speciesReference id="y_stoich" species="y" stoichiometry="1" constant="false">
             <comp:listOfReplacedElements>
@@ -43,7 +43,7 @@
         <species id="x" compartment="default_compartment" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
       </listOfSpecies>
       <listOfReactions>
-        <reaction id="J0" reversible="true" fast="false">
+        <reaction id="J0" reversible="true">
           <listOfReactants>
             <speciesReference id="x_stoich" species="x" stoichiometry="1" constant="false"/>
           </listOfReactants>

--- a/src/test/test-data/from-libsbml/test57.xml
+++ b/src/test/test-data/from-libsbml/test57.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.4 with libSBML version 5.8.0. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar" id="bar" name="bar">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true">
@@ -14,7 +14,7 @@
       <species id="z" compartment="default_compartment" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfReactions>
-      <reaction id="J1" reversible="true" fast="false">
+      <reaction id="J1" reversible="true">
         <listOfProducts>
           <speciesReference species="y" stoichiometry="1" constant="true"/>
         </listOfProducts>
@@ -22,7 +22,7 @@
           <comp:replacedElement comp:idRef="J0" comp:submodelRef="A"/>
         </comp:listOfReplacedElements>
       </reaction>
-      <reaction id="J2" reversible="true" fast="false">
+      <reaction id="J2" reversible="true">
         <listOfProducts>
           <speciesReference id="z_stoich" species="z" stoichiometry="1" constant="true">
             <comp:listOfReplacedElements>
@@ -56,7 +56,7 @@
         </initialAssignment>
       </listOfInitialAssignments>
       <listOfReactions>
-        <reaction id="J0" reversible="true" fast="false">
+        <reaction id="J0" reversible="true">
           <listOfReactants>
             <speciesReference id="x_stoich" species="x" stoichiometry="1" constant="true"/>
           </listOfReactants>

--- a/src/test/test-data/from-libsbml/test58.xml
+++ b/src/test/test-data/from-libsbml/test58.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.4 with libSBML version 5.8.0. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar" id="bar">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true">
@@ -14,13 +14,13 @@
       <species id="z" compartment="default_compartment" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfReactions>
-      <reaction id="J1" reversible="true" fast="false">
+      <reaction id="J1" reversible="true">
         <listOfProducts>
           <speciesReference species="y" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <comp:replacedBy comp:idRef="J0" comp:submodelRef="A"/>
       </reaction>
-      <reaction id="J2" reversible="true" fast="false">
+      <reaction id="J2" reversible="true">
         <listOfProducts>
           <speciesReference id="z_stoich" species="z" stoichiometry="1" constant="true">
             <comp:listOfReplacedElements>
@@ -54,7 +54,7 @@
         </initialAssignment>
       </listOfInitialAssignments>
       <listOfReactions>
-        <reaction id="J0" reversible="true" fast="false">
+        <reaction id="J0" reversible="true">
           <listOfReactants>
             <speciesReference id="x_stoich" species="x" stoichiometry="1" constant="true"/>
             <speciesReference id="x_stoich2" species="x" stoichiometry="1" constant="true"/>

--- a/src/test/test-data/from-libsbml/test58_flat.xml
+++ b/src/test/test-data/from-libsbml/test58_flat.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" level="3" version="1">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2">
   <model metaid="bar" id="bar">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
@@ -10,13 +10,13 @@
       <species id="z" compartment="default_compartment" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfReactions>
-      <reaction id="J1" reversible="true" fast="false">
+      <reaction id="J1" reversible="true">
         <listOfReactants>
           <speciesReference id="A__x_stoich" species="A__x" stoichiometry="1" constant="true"/>
           <speciesReference id="A__x_stoich2" species="A__x" stoichiometry="1" constant="true"/>
         </listOfReactants>
       </reaction>
-      <reaction id="J2" reversible="true" fast="false">
+      <reaction id="J2" reversible="true">
         <listOfProducts>
           <speciesReference id="z_stoich" species="z" stoichiometry="1" constant="true"/>
         </listOfProducts>

--- a/src/test/test-data/from-libsbml/test59.xml
+++ b/src/test/test-data/from-libsbml/test59.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.4 with libSBML version 5.8.0. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar" id="bar">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true">
@@ -25,13 +25,13 @@
       </initialAssignment>
     </listOfInitialAssignments>
     <listOfReactions>
-      <reaction id="J1" reversible="true" fast="false">
+      <reaction id="J1" reversible="true">
         <listOfProducts>
           <speciesReference species="y" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <comp:replacedBy comp:idRef="J0" comp:submodelRef="A"/>
       </reaction>
-      <reaction id="J2" reversible="true" fast="false">
+      <reaction id="J2" reversible="true">
         <listOfProducts>
           <speciesReference id="z_stoich" species="z" stoichiometry="1" constant="true">
             <comp:replacedBy comp:idRef="x_stoich" comp:submodelRef="A"/>
@@ -53,7 +53,7 @@
         <species id="x" compartment="default_compartment" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
       </listOfSpecies>
       <listOfReactions>
-        <reaction id="J0" reversible="true" fast="false">
+        <reaction id="J0" reversible="true">
           <listOfReactants>
             <speciesReference id="x_stoich" species="x" stoichiometry="1" constant="true"/>
           </listOfReactants>

--- a/src/test/test-data/from-libsbml/test59_flat.xml
+++ b/src/test/test-data/from-libsbml/test59_flat.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" level="3" version="1">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2">
   <model metaid="bar" id="bar">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
@@ -10,12 +10,12 @@
       <species id="z" compartment="default_compartment" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfReactions>
-      <reaction id="J1" reversible="true" fast="false">
+      <reaction id="J1" reversible="true">
         <listOfReactants>
           <speciesReference id="A__x_stoich" species="A__x" stoichiometry="1" constant="true"/>
         </listOfReactants>
       </reaction>
-      <reaction id="J2" reversible="true" fast="false">
+      <reaction id="J2" reversible="true">
         <listOfProducts>
           <speciesReference id="z_stoich" species="z" stoichiometry="1" constant="true"/>
           <speciesReference id="z_stoich2" species="z" stoichiometry="1" constant="true"/>

--- a/src/test/test-data/from-libsbml/test6.xml
+++ b/src/test/test-data/from-libsbml/test6.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model name="doc0">
     <listOfParameters>
       <parameter id="param1" value="10.42" constant="true">

--- a/src/test/test-data/from-libsbml/test60.xml
+++ b/src/test/test-data/from-libsbml/test60.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.4 with libSBML version 5.8.0. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar" id="bar" name="bar">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true">
@@ -13,7 +13,7 @@
       <species id="y" compartment="default_compartment" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfReactions>
-      <reaction id="J1" reversible="true" fast="false">
+      <reaction id="J1" reversible="true">
         <listOfProducts>
           <speciesReference species="y" stoichiometry="1" constant="true"/>
         </listOfProducts>
@@ -39,7 +39,7 @@
         <species id="x" compartment="default_compartment" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
       </listOfSpecies>
       <listOfReactions>
-        <reaction id="J0" reversible="true" fast="false">
+        <reaction id="J0" reversible="true">
           <listOfReactants>
             <speciesReference id="x_stoich" species="x" stoichiometry="1" constant="true"/>
           </listOfReactants>

--- a/src/test/test-data/from-libsbml/test61.xml
+++ b/src/test/test-data/from-libsbml/test61.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model id="aggregate" name="aggregate" timeUnits="second" extentUnits="mole">
     <listOfCompartments>
       <compartment id="c" spatialDimensions="3" size="1" units="litre" constant="true"/>
@@ -9,7 +9,7 @@
       <species id="S1" compartment="c" initialAmount="1" substanceUnits="mole" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfReactions>
-      <reaction id="R1" reversible="false" fast="false">
+      <reaction id="R1" reversible="false">
         <listOfReactants>
           <speciesReference id="S1_stoich" species="S1" constant="false">
             <comp:replacedBy comp:metaIdRef="__S1" comp:submodelRef="submod1"/>
@@ -56,7 +56,7 @@
         <species id="S1" compartment="c" initialAmount="1" substanceUnits="mole" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
       </listOfSpecies>
       <listOfReactions>
-        <reaction id="R1" reversible="false" fast="false">
+        <reaction id="R1" reversible="false">
           <listOfReactants>
             <speciesReference id="S1_stoich" metaid="__S1" species="S1" constant="false"/>
           </listOfReactants>

--- a/src/test/test-data/from-libsbml/test61_flat.xml
+++ b/src/test/test-data/from-libsbml/test61_flat.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" level="3" version="1">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2">
   <model id="aggregate" name="aggregate" timeUnits="time_unit" extentUnits="extent">
     <listOfUnitDefinitions>
       <unitDefinition id="submod1__extent">
@@ -49,7 +49,7 @@
       <parameter id="R1_k" value="0.1" units="second" constant="true"/>
     </listOfParameters>
     <listOfReactions>
-      <reaction id="submod1__R1" reversible="false" fast="false">
+      <reaction id="submod1__R1" reversible="false">
         <listOfReactants>
           <speciesReference id="submod1__S1_stoich" species="submod1__S1" constant="true"/>
         </listOfReactants>
@@ -63,7 +63,7 @@
           </math>
         </kineticLaw>
       </reaction>
-      <reaction id="R1" reversible="false" fast="false">
+      <reaction id="R1" reversible="false">
         <listOfReactants>
           <speciesReference id="S1_stoich" species="S1" constant="true"/>
         </listOfReactants>

--- a/src/test/test-data/from-libsbml/test7.xml
+++ b/src/test/test-data/from-libsbml/test7.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model name="doc0">
     <listOfParameters>
       <parameter id="param1" value="10.42" constant="false">

--- a/src/test/test-data/from-libsbml/test8.xml
+++ b/src/test/test-data/from-libsbml/test8.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model name="doc0">
     <listOfParameters>
       <parameter id="param1" value="10.42" constant="false">

--- a/src/test/test-data/from-libsbml/test9.xml
+++ b/src/test/test-data/from-libsbml/test9.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model name="doc0">
     <listOfCompartments>
       <compartment id="C" spatialDimensions="3" size="10" constant="false"/>

--- a/src/test/test-data/function_name.xml
+++ b/src/test/test-data/function_name.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.12.0 with libSBML version 5.18.0. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfFunctionDefinitions>
       <functionDefinition id="foo" name="foo!">

--- a/src/test/test-data/global_units.xml
+++ b/src/test/test-data/global_units.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main" substanceUnits="substance" timeUnits="time_unit" volumeUnits="volume" areaUnits="area" lengthUnits="length" extentUnits="extent">
     <listOfUnitDefinitions>
       <unitDefinition id="length">

--- a/src/test/test-data/hasPart.xml
+++ b/src/test/test-data/hasPart.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.12.0 with libSBML version 5.18.0. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter metaid="__main.a" id="a" value="3" constant="true">

--- a/src/test/test-data/hasProperty.xml
+++ b/src/test/test-data/hasProperty.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.12.0 with libSBML version 5.18.0. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter metaid="__main.a" id="a" value="3" constant="true">

--- a/src/test/test-data/hasTaxon.xml
+++ b/src/test/test-data/hasTaxon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.12.0 with libSBML version 5.18.0. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter metaid="__main.a" id="a" value="3" constant="true">

--- a/src/test/test-data/hasVersion.xml
+++ b/src/test/test-data/hasVersion.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.12.0 with libSBML version 5.18.0. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter metaid="__main.a" id="a" value="3" constant="true">

--- a/src/test/test-data/hierarchy.xml
+++ b/src/test/test-data/hierarchy.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar" id="bar">
     <comp:listOfSubmodels>
       <comp:submodel comp:id="A" comp:modelRef="foo"/>

--- a/src/test/test-data/hierarchy_flat.xml
+++ b/src/test/test-data/hierarchy_flat.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" level="3" version="1">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2">
   <model metaid="bar" id="bar">
     <listOfParameters>
       <parameter id="A_x" value="3" constant="true"/>

--- a/src/test/test-data/identity.xml
+++ b/src/test/test-data/identity.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.12.0 with libSBML version 5.18.0. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter metaid="__main.a" id="a" value="3" constant="true">

--- a/src/test/test-data/initialAmount.xml
+++ b/src/test/test-data/initialAmount.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfCompartments>
       <compartment id="C" spatialDimensions="3" constant="true"/>

--- a/src/test/test-data/initialAssignment.xml
+++ b/src/test/test-data/initialAssignment.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter id="x" constant="true"/>

--- a/src/test/test-data/initialConcentration.xml
+++ b/src/test/test-data/initialConcentration.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>

--- a/src/test/test-data/initialValue.xml
+++ b/src/test/test-data/initialValue.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter id="x" value="3" constant="true"/>

--- a/src/test/test-data/interactionActivation.xml
+++ b/src/test/test-data/interactionActivation.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
@@ -9,7 +9,7 @@
       <species id="S2" compartment="default_compartment" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfReactions>
-      <reaction id="J0" reversible="true" fast="false">
+      <reaction id="J0" reversible="true">
         <listOfReactants>
           <speciesReference species="S1" stoichiometry="1" constant="true"/>
         </listOfReactants>

--- a/src/test/test-data/interactionGeneric.xml
+++ b/src/test/test-data/interactionGeneric.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
@@ -9,7 +9,7 @@
       <species id="S2" compartment="default_compartment" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfReactions>
-      <reaction id="J0" reversible="true" fast="false">
+      <reaction id="J0" reversible="true">
         <listOfReactants>
           <speciesReference species="S1" stoichiometry="1" constant="true"/>
         </listOfReactants>

--- a/src/test/test-data/interactionInhibition.xml
+++ b/src/test/test-data/interactionInhibition.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
@@ -9,7 +9,7 @@
       <species id="S2" compartment="default_compartment" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfReactions>
-      <reaction id="J0" reversible="true" fast="false">
+      <reaction id="J0" reversible="true">
         <listOfReactants>
           <speciesReference species="S1" stoichiometry="1" constant="true"/>
         </listOfReactants>

--- a/src/test/test-data/interquartileRange.xml
+++ b/src/test/test-data/interquartileRange.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.12.0 with libSBML version 5.18.1. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" level="3" version="1" comp:required="true" distrib:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" level="3" version="2" comp:required="true" distrib:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter id="a" constant="true">

--- a/src/test/test-data/isDescribedBy.xml
+++ b/src/test/test-data/isDescribedBy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.12.0 with libSBML version 5.18.0. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter metaid="__main.a" id="a" value="3" constant="true">

--- a/src/test/test-data/isEncodedBy.xml
+++ b/src/test/test-data/isEncodedBy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.12.0 with libSBML version 5.18.0. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter metaid="__main.a" id="a" value="3" constant="true">

--- a/src/test/test-data/isHomologTo.xml
+++ b/src/test/test-data/isHomologTo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.12.0 with libSBML version 5.18.0. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter metaid="__main.a" id="a" value="3" constant="true">

--- a/src/test/test-data/isPartOf.xml
+++ b/src/test/test-data/isPartOf.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.12.0 with libSBML version 5.18.0. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter metaid="__main.a" id="a" value="3" constant="true">

--- a/src/test/test-data/isPropertyOf.xml
+++ b/src/test/test-data/isPropertyOf.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.12.0 with libSBML version 5.18.0. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter metaid="__main.a" id="a" value="3" constant="true">

--- a/src/test/test-data/isVersionOf.xml
+++ b/src/test/test-data/isVersionOf.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.12.0 with libSBML version 5.18.0. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter metaid="__main.a" id="a" value="3" constant="true">

--- a/src/test/test-data/kurtosis.xml
+++ b/src/test/test-data/kurtosis.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.12.0 with libSBML version 5.18.0. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" level="3" version="1" comp:required="true" distrib:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" level="3" version="2" comp:required="true" distrib:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter id="a" constant="true">

--- a/src/test/test-data/mean.xml
+++ b/src/test/test-data/mean.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" level="3" version="1" comp:required="true" distrib:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" level="3" version="2" comp:required="true" distrib:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter id="a" constant="true">

--- a/src/test/test-data/median.xml
+++ b/src/test/test-data/median.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.12.0 with libSBML version 5.18.0. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" level="3" version="1" comp:required="true" distrib:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" level="3" version="2" comp:required="true" distrib:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter id="a" constant="true">

--- a/src/test/test-data/mode.xml
+++ b/src/test/test-data/mode.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.12.0 with libSBML version 5.18.0. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" level="3" version="1" comp:required="true" distrib:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" level="3" version="2" comp:required="true" distrib:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter id="a" constant="true">

--- a/src/test/test-data/module_name.xml
+++ b/src/test/test-data/module_name.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.12.0 with libSBML version 5.18.0. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="foo" id="foo" name="foo!">
     <listOfParameters>
       <parameter id="a" value="3" constant="true"/>

--- a/src/test/test-data/namedstoich_assignment.xml
+++ b/src/test/test-data/namedstoich_assignment.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
@@ -19,7 +19,7 @@
       </assignmentRule>
     </listOfRules>
     <listOfReactions>
-      <reaction id="J0" reversible="true" fast="false">
+      <reaction id="J0" reversible="true">
         <listOfReactants>
           <speciesReference id="sr1" species="a" constant="false"/>
         </listOfReactants>

--- a/src/test/test-data/namedstoich_basic.xml
+++ b/src/test/test-data/namedstoich_basic.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.13.0 with libSBML version 5.19.2. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
@@ -9,7 +9,7 @@
       <species id="a" compartment="default_compartment" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfReactions>
-      <reaction id="J0" reversible="true" fast="false">
+      <reaction id="J0" reversible="true">
         <listOfReactants>
           <speciesReference id="sr1" species="a" constant="true"/>
         </listOfReactants>

--- a/src/test/test-data/namedstoich_rate.xml
+++ b/src/test/test-data/namedstoich_rate.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.13.0 with libSBML version 5.19.2. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
@@ -16,7 +16,7 @@
       </rateRule>
     </listOfRules>
     <listOfReactions>
-      <reaction id="J0" reversible="true" fast="false">
+      <reaction id="J0" reversible="true">
         <listOfReactants>
           <speciesReference id="sr1" species="a" constant="false"/>
         </listOfReactants>

--- a/src/test/test-data/namedstoich_value.xml
+++ b/src/test/test-data/namedstoich_value.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.13.0 with libSBML version 5.19.2. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
@@ -9,7 +9,7 @@
       <species id="a" compartment="default_compartment" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfReactions>
-      <reaction id="J0" reversible="true" fast="false">
+      <reaction id="J0" reversible="true">
         <listOfReactants>
           <speciesReference id="sr1" species="a" stoichiometry="2" constant="true"/>
         </listOfReactants>

--- a/src/test/test-data/names.xml
+++ b/src/test/test-data/names.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter id="x" name="This Name!" constant="true"/>

--- a/src/test/test-data/negparen.xml
+++ b/src/test/test-data/negparen.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.12.0 with libSBML version 5.18.0. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter id="a" constant="true"/>

--- a/src/test/test-data/occursIn.xml
+++ b/src/test/test-data/occursIn.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.12.0 with libSBML version 5.18.0. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter metaid="__main.a" id="a" value="3" constant="true">

--- a/src/test/test-data/parameter.xml
+++ b/src/test/test-data/parameter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter id="a" value="3" constant="true"/>

--- a/src/test/test-data/parameter_inf.xml
+++ b/src/test/test-data/parameter_inf.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter id="a" value="INF" constant="true"/>

--- a/src/test/test-data/parameter_nan.xml
+++ b/src/test/test-data/parameter_nan.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter id="a" value="NaN" constant="true"/>

--- a/src/test/test-data/parameter_neginf.xml
+++ b/src/test/test-data/parameter_neginf.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter id="a" value="-INF" constant="true"/>

--- a/src/test/test-data/port.xml
+++ b/src/test/test-data/port.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar" id="bar">
     <listOfParameters>
       <parameter id="X" value="3" constant="true">

--- a/src/test/test-data/range.xml
+++ b/src/test/test-data/range.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.12.0 with libSBML version 5.18.1. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" level="3" version="1" comp:required="true" distrib:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" level="3" version="2" comp:required="true" distrib:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter id="a" constant="true">

--- a/src/test/test-data/rateRule.xml
+++ b/src/test/test-data/rateRule.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter id="x" constant="false"/>

--- a/src/test/test-data/reaction.xml
+++ b/src/test/test-data/reaction.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
@@ -11,7 +11,7 @@
       <parameter id="k1" constant="true"/>
     </listOfParameters>
     <listOfReactions>
-      <reaction id="J0" reversible="true" fast="false">
+      <reaction id="J0" reversible="true">
         <listOfReactants>
           <speciesReference species="a" stoichiometry="1" constant="true"/>
         </listOfReactants>

--- a/src/test/test-data/reactionIn.xml
+++ b/src/test/test-data/reactionIn.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfCompartments>
       <compartment id="C" spatialDimensions="3" constant="true"/>
@@ -11,7 +11,7 @@
       <parameter id="k1" constant="true"/>
     </listOfParameters>
     <listOfReactions>
-      <reaction id="J0" reversible="true" fast="false" compartment="C">
+      <reaction id="J0" reversible="true" compartment="C">
         <listOfProducts>
           <speciesReference species="a" stoichiometry="1" constant="true"/>
         </listOfProducts>

--- a/src/test/test-data/replaceAssignmentRule.xml
+++ b/src/test/test-data/replaceAssignmentRule.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar" id="bar">
     <listOfParameters>
       <parameter id="y" value="2.2" constant="false">

--- a/src/test/test-data/replaceCompartment.xml
+++ b/src/test/test-data/replaceCompartment.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar" id="bar">
     <listOfCompartments>
       <compartment id="y" spatialDimensions="3" size="2.2" constant="true">

--- a/src/test/test-data/replaceInitialAssignment.xml
+++ b/src/test/test-data/replaceInitialAssignment.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar" id="bar">
     <listOfParameters>
       <parameter id="y" constant="true">

--- a/src/test/test-data/replaceInteraction.xml
+++ b/src/test/test-data/replaceInteraction.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar" id="bar">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true">
@@ -17,7 +17,7 @@
       </species>
     </listOfSpecies>
     <listOfReactions>
-      <reaction id="J1" reversible="true" fast="false">
+      <reaction id="J1" reversible="true">
         <listOfReactants>
           <speciesReference species="A__x" stoichiometry="1" constant="true"/>
         </listOfReactants>
@@ -43,7 +43,7 @@
         <species id="x" compartment="default_compartment" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
       </listOfSpecies>
       <listOfReactions>
-        <reaction id="J0" reversible="true" fast="false">
+        <reaction id="J0" reversible="true">
           <listOfReactants>
             <speciesReference species="x" stoichiometry="1" constant="true"/>
           </listOfReactants>

--- a/src/test/test-data/replaceParameter.xml
+++ b/src/test/test-data/replaceParameter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar" id="bar">
     <listOfParameters>
       <parameter id="y" value="2.2" constant="true">

--- a/src/test/test-data/replaceRateRule.xml
+++ b/src/test/test-data/replaceRateRule.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar" id="bar">
     <listOfParameters>
       <parameter id="y" constant="false">

--- a/src/test/test-data/replaceReactionOnly.xml
+++ b/src/test/test-data/replaceReactionOnly.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar" id="bar">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true">
@@ -14,7 +14,7 @@
       </species>
     </listOfSpecies>
     <listOfReactions>
-      <reaction id="J1" reversible="true" fast="false">
+      <reaction id="J1" reversible="true">
         <listOfReactants>
           <speciesReference species="A__x" stoichiometry="1" constant="true"/>
         </listOfReactants>
@@ -36,7 +36,7 @@
         <species id="x" compartment="default_compartment" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
       </listOfSpecies>
       <listOfReactions>
-        <reaction id="J0" reversible="true" fast="false">
+        <reaction id="J0" reversible="true">
           <listOfReactants>
             <speciesReference species="x" stoichiometry="1" constant="true"/>
           </listOfReactants>

--- a/src/test/test-data/replaceReactionOnly2.xml
+++ b/src/test/test-data/replaceReactionOnly2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar" id="bar">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true">
@@ -14,7 +14,7 @@
       </species>
     </listOfSpecies>
     <listOfReactions>
-      <reaction id="J1" reversible="true" fast="false">
+      <reaction id="J1" reversible="true">
         <listOfProducts>
           <speciesReference species="A__x" stoichiometry="1" constant="true"/>
         </listOfProducts>
@@ -36,7 +36,7 @@
         <species id="x" compartment="default_compartment" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
       </listOfSpecies>
       <listOfReactions>
-        <reaction id="J0" reversible="true" fast="false">
+        <reaction id="J0" reversible="true">
           <listOfProducts>
             <speciesReference species="x" stoichiometry="1" constant="true"/>
           </listOfProducts>

--- a/src/test/test-data/replaceReactionWithCompartments1.xml
+++ b/src/test/test-data/replaceReactionWithCompartments1.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar" id="bar">
     <listOfCompartments>
       <compartment id="A__C2" constant="false">
@@ -12,7 +12,7 @@
       </species>
     </listOfSpecies>
     <listOfReactions>
-      <reaction id="J1" reversible="true" fast="false">
+      <reaction id="J1" reversible="true">
         <listOfReactants>
           <speciesReference species="A__x" stoichiometry="1" constant="true"/>
         </listOfReactants>
@@ -34,7 +34,7 @@
         <species id="x" compartment="C2" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
       </listOfSpecies>
       <listOfReactions>
-        <reaction id="J0" reversible="true" fast="false">
+        <reaction id="J0" reversible="true">
           <listOfReactants>
             <speciesReference species="x" stoichiometry="1" constant="true"/>
           </listOfReactants>

--- a/src/test/test-data/replaceReactionWithCompartments2.xml
+++ b/src/test/test-data/replaceReactionWithCompartments2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar" id="bar">
     <listOfCompartments>
       <compartment id="A__C1" constant="false">
@@ -15,7 +15,7 @@
       </species>
     </listOfSpecies>
     <listOfReactions>
-      <reaction id="J1" reversible="true" fast="false" compartment="A__C1">
+      <reaction id="J1" reversible="true" compartment="A__C1">
         <listOfReactants>
           <speciesReference species="A__x" stoichiometry="1" constant="true"/>
         </listOfReactants>
@@ -38,7 +38,7 @@
         <species id="x" compartment="C2" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
       </listOfSpecies>
       <listOfReactions>
-        <reaction id="J0" reversible="true" fast="false" compartment="C1">
+        <reaction id="J0" reversible="true" compartment="C1">
           <listOfReactants>
             <speciesReference species="x" stoichiometry="1" constant="true"/>
           </listOfReactants>

--- a/src/test/test-data/replaceReactionWithKineticLaw.xml
+++ b/src/test/test-data/replaceReactionWithKineticLaw.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar" id="bar">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true">
@@ -19,7 +19,7 @@
       </parameter>
     </listOfParameters>
     <listOfReactions>
-      <reaction id="J1" reversible="true" fast="false">
+      <reaction id="J1" reversible="true">
         <listOfReactants>
           <speciesReference species="A__S1" stoichiometry="1" constant="true"/>
         </listOfReactants>
@@ -49,7 +49,7 @@
         <parameter id="x" constant="true"/>
       </listOfParameters>
       <listOfReactions>
-        <reaction id="J0" reversible="true" fast="false">
+        <reaction id="J0" reversible="true">
           <listOfReactants>
             <speciesReference species="S1" stoichiometry="1" constant="true"/>
           </listOfReactants>

--- a/src/test/test-data/replaceReactionWithKineticLawRxnRef.xml
+++ b/src/test/test-data/replaceReactionWithKineticLawRxnRef.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar" id="bar">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true">
@@ -19,7 +19,7 @@
       </parameter>
     </listOfParameters>
     <listOfReactions>
-      <reaction id="Jtop" reversible="true" fast="false">
+      <reaction id="Jtop" reversible="true">
         <listOfReactants>
           <speciesReference species="A__S1" stoichiometry="1" constant="true"/>
         </listOfReactants>
@@ -46,7 +46,7 @@
         <species id="S1" compartment="default_compartment" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
       </listOfSpecies>
       <listOfReactions>
-        <reaction id="J0" reversible="true" fast="false">
+        <reaction id="J0" reversible="true">
           <listOfReactants>
             <speciesReference species="S1" stoichiometry="1" constant="true"/>
           </listOfReactants>
@@ -56,7 +56,7 @@
             </math>
           </kineticLaw>
         </reaction>
-        <reaction id="J1" reversible="true" fast="false">
+        <reaction id="J1" reversible="true">
           <listOfProducts>
             <speciesReference species="S1" stoichiometry="1" constant="true"/>
           </listOfProducts>

--- a/src/test/test-data/replaceSpecies.xml
+++ b/src/test/test-data/replaceSpecies.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar1" id="bar1">
     <listOfCompartments>
       <compartment id="A__C1" constant="false">

--- a/src/test/test-data/replaceSpeciesDefaultCompartment.xml
+++ b/src/test/test-data/replaceSpeciesDefaultCompartment.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar1" id="bar1">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true">

--- a/src/test/test-data/rxn_right.xml
+++ b/src/test/test-data/rxn_right.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
@@ -8,7 +8,7 @@
       <species id="S1" compartment="default_compartment" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfReactions>
-      <reaction id="_J0" reversible="true" fast="false">
+      <reaction id="_J0" reversible="true">
         <listOfProducts>
           <speciesReference species="S1" stoichiometry="1" constant="true"/>
         </listOfProducts>

--- a/src/test/test-data/rxn_right_mod.xml
+++ b/src/test/test-data/rxn_right_mod.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="foo" id="foo">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
@@ -8,7 +8,7 @@
       <species id="S1" compartment="default_compartment" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfReactions>
-      <reaction id="_J0" reversible="true" fast="false">
+      <reaction id="_J0" reversible="true">
         <listOfProducts>
           <speciesReference species="S1" stoichiometry="1" constant="true"/>
         </listOfProducts>

--- a/src/test/test-data/same_unit_name.xml
+++ b/src/test/test-data/same_unit_name.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.13.0 with libSBML version 5.18.1. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" level="3" version="1">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2">
   <model metaid="same_units" id="same_units">
     <listOfUnitDefinitions>
       <unitDefinition id="x">

--- a/src/test/test-data/sampleSize.xml
+++ b/src/test/test-data/sampleSize.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.12.0 with libSBML version 5.18.0. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" level="3" version="1" comp:required="true" distrib:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" level="3" version="2" comp:required="true" distrib:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter id="a" constant="true">

--- a/src/test/test-data/skewness.xml
+++ b/src/test/test-data/skewness.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.12.0 with libSBML version 5.18.0. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" level="3" version="1" comp:required="true" distrib:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" level="3" version="2" comp:required="true" distrib:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter id="a" constant="true">

--- a/src/test/test-data/species.xml
+++ b/src/test/test-data/species.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfCompartments>
       <compartment id="y" spatialDimensions="3" constant="true"/>

--- a/src/test/test-data/standardDeviation.xml
+++ b/src/test/test-data/standardDeviation.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.12.0 with libSBML version 5.18.0. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" level="3" version="1" comp:required="true" distrib:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" level="3" version="2" comp:required="true" distrib:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter id="a" constant="true">

--- a/src/test/test-data/standardError.xml
+++ b/src/test/test-data/standardError.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.12.0 with libSBML version 5.18.0. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" level="3" version="1" comp:required="true" distrib:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" level="3" version="2" comp:required="true" distrib:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter id="a" constant="true">

--- a/src/test/test-data/submodelInteraction.xml
+++ b/src/test/test-data/submodelInteraction.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="bar" id="bar">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true">
@@ -22,7 +22,7 @@
         <species id="x" compartment="default_compartment" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
       </listOfSpecies>
       <listOfReactions>
-        <reaction id="J0" reversible="true" fast="false">
+        <reaction id="J0" reversible="true">
           <listOfReactants>
             <speciesReference species="x" stoichiometry="1" constant="true"/>
           </listOfReactants>

--- a/src/test/test-data/subport.xml
+++ b/src/test/test-data/subport.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="baz" id="baz">
     <listOfParameters>
       <parameter id="x2" value="3" constant="true">

--- a/src/test/test-data/subport2.xml
+++ b/src/test/test-data/subport2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="baz" id="baz">
     <listOfParameters>
       <parameter id="x1" value="3" constant="true">

--- a/src/test/test-data/substance_only_species.xml
+++ b/src/test/test-data/substance_only_species.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>

--- a/src/test/test-data/subsubport.xml
+++ b/src/test/test-data/subsubport.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="biff" id="biff">
     <listOfParameters>
       <parameter id="x1" value="3" constant="true">

--- a/src/test/test-data/units.xml
+++ b/src/test/test-data/units.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="1" comp:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
   <model metaid="__main" id="__main">
     <listOfUnitDefinitions>
       <unitDefinition id="mL">

--- a/src/test/test-data/variance.xml
+++ b/src/test/test-data/variance.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.12.0 with libSBML version 5.18.0. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" level="3" version="1" comp:required="true" distrib:required="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" level="3" version="2" comp:required="true" distrib:required="true">
   <model metaid="__main" id="__main">
     <listOfParameters>
       <parameter id="a" constant="true">


### PR DESCRIPTION
Update to using l3v2 by default.

(Also, use latest libsbml; updated in libroadrunner-deps)