### PR TITLE
Change how substanceOnly species are initialized.

### DIFF
--- a/src/formula.cpp
+++ b/src/formula.cpp
@@ -309,9 +309,34 @@ bool Formula::IsAmountIn(const Variable* compartment) const
   return false;
 }
 
-double Formula::ToAmount() const
+bool Formula::IsConcentrationTimes(const Variable* compartment) const
 {
-  //We will assume that 'IsAmountIn' returned true.
+  if (compartment == NULL) return false;
+  size_t check = 0;
+  if (m_components.size() == 3) {
+    if (m_components[0].second.size() == 0) {
+      if (IsReal(m_components[0].first)) {
+        check = 1;
+      }
+    }
+  }
+  else if (m_components.size() == 4) {
+    if (m_components[0].second.size() == 0 && m_components[0].first == "-" &&
+      m_components[1].second.size() == 0 && IsReal(m_components[1].first)) {
+      check = 2;;
+    }
+  }
+  if (check == 0) return false;
+  if (m_components[check].second.size() == 0 && m_components[check].first == "*" &&
+    m_components[check + 1].second == compartment->GetName()) {
+    return true;
+  }
+  return false;
+}
+
+double Formula::ToAmountOrConcentration() const
+{
+  //We will assume that 'IsAmountIn' or 'IsConcentrationTimes' returned true.
   if (m_components.size() == 3) {
     return GetReal(m_components[0].first);
   }

--- a/src/formula.h
+++ b/src/formula.h
@@ -53,6 +53,7 @@ public:
   bool IsBoolean() const;
   bool GetBoolean() const;
   bool IsAmountIn(const Variable* compartment) const;
+  bool IsConcentrationTimes(const Variable* compartment) const;
   bool IsOne() const;
   bool IsEllipsesOnly() const;
   bool IsSingleVariable() const;
@@ -74,7 +75,7 @@ public:
   std::string ToDelimitedStringWithEllipses(std::string cc) const;
   std::string ToSBMLString() const;
   std::string ToSBMLString(std::vector<std::pair<Variable*, size_t> > strands) const;
-  double      ToAmount() const;
+  double      ToAmountOrConcentration() const;
   std::string ConvertOneSymbolToFunction(std::string formula) const;
   std::vector<const Variable*> GetVariablesFrom(std::string formula, std::string module) const;
   std::vector<Variable*> GetVariables() const;

--- a/src/module-sbml.cpp
+++ b/src/module-sbml.cpp
@@ -1208,16 +1208,27 @@ void Module::LoadSBML(Model* sbml)
     if (species->isSetInitialAmount()) {
       double amount = species->getInitialAmount();
       formula.AddNum(amount);
-      if (amount != 0 && defaultcompartments.find(species->getCompartment()) == defaultcompartments.end()) {
-        Variable* compartment = AddOrFindVariable(&(species->getCompartment()));
-        Formula* compform = compartment->GetFormula();
-        formula.AddMathThing('/');
-        formula.AddVariable(compartment);
+      if (!species->getHasOnlySubstanceUnits()) {
+        if (amount != 0 && defaultcompartments.find(species->getCompartment()) == defaultcompartments.end()) {
+          Variable* compartment = AddOrFindVariable(&(species->getCompartment()));
+          Formula* compform = compartment->GetFormula();
+          formula.AddMathThing('/');
+          formula.AddVariable(compartment);
+        }
       }
       var->SetFormula(&formula);
     }
     else if (species->isSetInitialConcentration()) {
-      formula.AddNum(species->getInitialConcentration());
+      double conc = species->getInitialConcentration();
+      formula.AddNum(conc);
+      if (species->getHasOnlySubstanceUnits()) {
+        if (conc != 0 && defaultcompartments.find(species->getCompartment()) == defaultcompartments.end()) {
+          Variable* compartment = AddOrFindVariable(&(species->getCompartment()));
+          Formula* compform = compartment->GetFormula();
+          formula.AddMathThing('/');
+          formula.AddVariable(compartment);
+        }
+      }
       var->SetFormula(&formula);
     }
     //Anything more complicated is set in a Rule, which we'll get to later.
@@ -2113,11 +2124,22 @@ void Module::CreateSBMLModel(bool comp)
     }
     Variable* unitvar = species->GetUnitVariable();
     Formula* formula = species->GetFormula();
-    if (formula->IsDouble()) {
-      sbmlspecies->setInitialConcentration(formula->GetDouble());
+    if (species->GetSubstOnly()) {
+      if (formula->IsDouble()) {
+        sbmlspecies->setInitialAmount(formula->GetDouble());
+      }
+      else if (formula->IsConcentrationTimes(compartment)) {
+        sbmlspecies->setInitialConcentration(formula->ToAmountOrConcentration());
+      }
     }
-    else if (formula->IsAmountIn(compartment)) {
-      sbmlspecies->setInitialAmount(formula->ToAmount());
+    else {
+      if (formula->IsDouble()) {
+        sbmlspecies->setInitialConcentration(formula->GetDouble());
+      }
+      else if (formula->IsAmountIn(compartment)) {
+        sbmlspecies->setInitialAmount(formula->ToAmountOrConcentration());
+      }
+
     }
     if (unitvar != NULL) {
       //We need to convert concentration to substance.
@@ -2800,14 +2822,24 @@ void Module::SetAssignmentFor(Model* sbmlmod, const Variable* var, const map<con
         ar->setMath(math);
       }
     }
-    else if (!formula->IsDouble() &&
-      !(IsSpecies(var->GetType()) && formula->IsAmountIn(var->GetCompartment()))) {
-        //if it was a double or a species with an amount, we already dealt with it.  Otherwise:
-        if (useassignment) {
-          InitialAssignment* ia = sbmlmod->createInitialAssignment();
-          ia->setSymbol(var->GetNameDelimitedBy(cc));
-          ia->setMath(math);
+    else if (!formula->IsDouble()) {
+      if (IsSpecies(var->GetType())) {
+        if (var->GetSubstOnly()) {
+          if (formula->IsConcentrationTimes(var->GetCompartment())) {
+            useassignment = false; //Already set 'initialAmount'
+          }
         }
+        else {
+          if (formula->IsAmountIn(var->GetCompartment())) {
+            useassignment = false; //Already set 'initialConcentration'
+          }
+        }
+      }
+      if (useassignment) {
+        InitialAssignment* ia = sbmlmod->createInitialAssignment();
+        ia->setSymbol(var->GetNameDelimitedBy(cc));
+        ia->setMath(math);
+      }
     }
     if (comp) {
       formula->AddReferencedVariablesTo(referencedVars);

--- a/src/test/TestAntimonyBasic.cpp
+++ b/src/test/TestAntimonyBasic.cpp
@@ -283,6 +283,12 @@ START_TEST (test_initialAmount)
 }
 END_TEST
 
+START_TEST(test_initialAmountsAndConcentrations)
+{
+  compareFileTranslation("initialAmountsAndConcentrations");
+}
+END_TEST
+
 START_TEST (test_initialAmount_txt)
 {
   compareStringTranslation("species x in C=3/C", "initialAmount.xml");
@@ -679,6 +685,7 @@ create_suite_Basic (void)
   tcase_add_test( tcase, test_initialConcentration);
   tcase_add_test( tcase, test_initialConcentration_txt);
   tcase_add_test( tcase, test_initialAmount);
+  tcase_add_test( tcase, test_initialAmountsAndConcentrations);
   tcase_add_test( tcase, test_initialAmount_txt);
   tcase_add_test( tcase, test_initialAssignment);
   tcase_add_test( tcase, test_initialAssignment_txt);

--- a/src/test/test-data/from-libsbml/CompTest_flat.xml
+++ b/src/test/test-data/from-libsbml/CompTest_flat.xml
@@ -81,8 +81,8 @@
       <compartment id="Cell" spatialDimensions="3" size="1" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S2" compartment="Cell" initialConcentration="0" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
-      <species id="S1" compartment="Cell" initialConcentration="0" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S2" compartment="Cell" initialAmount="0" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S1" compartment="Cell" initialAmount="0" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
       <parameter id="C1__V1" constant="false"/>

--- a/src/test/test-data/from-libsbml/test22.txt
+++ b/src/test/test-data/from-libsbml/test22.txt
@@ -24,7 +24,7 @@ model moddef1()
   constraint _con0: time < (t4*t5)
 
   // Species initializations:
-  s1 = 0.001/C;
+  s1 = 0.001;
 
   // Compartment initializations:
   C = 1;

--- a/src/test/test-data/from-libsbml/test23.txt
+++ b/src/test/test-data/from-libsbml/test23.txt
@@ -24,7 +24,7 @@ model moddef1()
   constraint _con0: time < (t4*t5)
 
   // Species initializations:
-  s1 = 1/C;
+  s1 = 1;
 
   // Compartment initializations:
   C = 1;

--- a/src/test/test-data/from-libsbml/test24.txt
+++ b/src/test/test-data/from-libsbml/test24.txt
@@ -9,7 +9,7 @@ model moddef1()
   J0:  -> s1; 10;
 
   // Species initializations:
-  s1 = 1/C;
+  s1 = 1;
 
   // Compartment initializations:
   C = 1;

--- a/src/test/test-data/from-libsbml/test25.txt
+++ b/src/test/test-data/from-libsbml/test25.txt
@@ -9,7 +9,7 @@ model moddef1()
   J0:  -> s1; s1*time/delay(s1, 2e4);
 
   // Species initializations:
-  s1 = 1/C;
+  s1 = 1;
 
   // Compartment initializations:
   C = 1;

--- a/src/test/test-data/from-libsbml/test28.txt
+++ b/src/test/test-data/from-libsbml/test28.txt
@@ -9,7 +9,7 @@ model moddef1()
   J0:  -> s1; s1*time/delay(s1, 2e4);
 
   // Species initializations:
-  s1 = 1/C;
+  s1 = 1;
 
   // Compartment initializations:
   C = 1;

--- a/src/test/test-data/from-libsbml/test39.txt
+++ b/src/test/test-data/from-libsbml/test39.txt
@@ -9,7 +9,7 @@ model moddef1()
   J0:  -> s1; J0_p1*s1;
 
   // Species initializations:
-  s1 = 0.001/C;
+  s1 = 0.001;
 
   // Compartment initializations:
   C = 1;

--- a/src/test/test-data/from-libsbml/test44.txt
+++ b/src/test/test-data/from-libsbml/test44.txt
@@ -12,7 +12,7 @@ model moddef1()
   J0:  -> s1; 10;
 
   // Species initializations:
-  s1 = 1/C;
+  s1 = 1;
 
   // Compartment initializations:
   C = 1;

--- a/src/test/test-data/from-libsbml/test46.txt
+++ b/src/test/test-data/from-libsbml/test46.txt
@@ -12,7 +12,7 @@ model moddef1()
   J0:  -> s1; 10;
 
   // Species initializations:
-  s1 = 1/C;
+  s1 = 1;
 
   // Compartment initializations:
   C = 1;

--- a/src/test/test-data/from-libsbml/test47.txt
+++ b/src/test/test-data/from-libsbml/test47.txt
@@ -12,7 +12,7 @@ model moddef1()
   J0:  -> s1; 10;
 
   // Species initializations:
-  s1 = 1/C;
+  s1 = 1;
 
   // Compartment initializations:
   C = 1;

--- a/src/test/test-data/from-libsbml/test48.txt
+++ b/src/test/test-data/from-libsbml/test48.txt
@@ -12,7 +12,7 @@ model moddef1()
   J0:  -> s1; ;
 
   // Species initializations:
-  s1 = 1/C;
+  s1 = 1;
 
   // Compartment initializations:
   C = 1;

--- a/src/test/test-data/initialAmountsAndConcentrations.txt
+++ b/src/test/test-data/initialAmountsAndConcentrations.txt
@@ -1,0 +1,12 @@
+species S1 in C, S2 in C, S3 in C, S4 in C
+S1 = 5     // Sets the initialConcentration to 5
+S2 = 5/C   // Sets the initialAmount to 5
+S3 = 5*1   // Sets an InitialAssignment, which assigns the concentration
+S4 = 5*C   // Sets an InitialAssignment, which assigns the concentration
+
+substanceOnly species S5 in C, S6 in C, S7 in C, S8 in C
+
+S5 = 5      // Sets the initialAmount to 5
+S6 = 5*C    // Sets the initialConcentration to 5
+S7 = 5*1    // Sets an InitialAssignment, which assigns the amount.
+S8 = 5/C    // Sets an InitialAssignment, which assigns the amount.

--- a/src/test/test-data/initialAmountsAndConcentrations.xml
+++ b/src/test/test-data/initialAmountsAndConcentrations.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created by libAntimony version v3.0.0 with libSBML version 5.20.5. -->
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
+  <model metaid="__main" id="__main">
+    <listOfCompartments>
+      <compartment id="C" spatialDimensions="3" constant="true"/>
+    </listOfCompartments>
+    <listOfSpecies>
+      <species id="S1" compartment="C" initialConcentration="5" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S2" compartment="C" initialAmount="5" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S3" compartment="C" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S4" compartment="C" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S5" compartment="C" initialAmount="5" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S6" compartment="C" initialConcentration="5" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S7" compartment="C" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+      <species id="S8" compartment="C" hasOnlySubstanceUnits="true" boundaryCondition="false" constant="false"/>
+    </listOfSpecies>
+    <listOfInitialAssignments>
+      <initialAssignment symbol="S3">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <apply>
+            <times/>
+            <cn type="integer"> 5 </cn>
+            <cn type="integer"> 1 </cn>
+          </apply>
+        </math>
+      </initialAssignment>
+      <initialAssignment symbol="S4">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <apply>
+            <times/>
+            <cn type="integer"> 5 </cn>
+            <ci> C </ci>
+          </apply>
+        </math>
+      </initialAssignment>
+      <initialAssignment symbol="S7">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <apply>
+            <times/>
+            <cn type="integer"> 5 </cn>
+            <cn type="integer"> 1 </cn>
+          </apply>
+        </math>
+      </initialAssignment>
+      <initialAssignment symbol="S8">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <apply>
+            <divide/>
+            <cn type="integer"> 5 </cn>
+            <ci> C </ci>
+          </apply>
+        </math>
+      </initialAssignment>
+    </listOfInitialAssignments>
+  </model>
+</sbml>

--- a/src/test/test-data/initialAmountsAndConcentrations_rt.txt
+++ b/src/test/test-data/initialAmountsAndConcentrations_rt.txt
@@ -1,0 +1,21 @@
+// Created by libAntimony v3.0.0
+// Compartments and Species:
+compartment C;
+species S1 in C, S2 in C, S3 in C, S4 in C;
+substanceOnly species S5 in C, S6 in C, S7 in C, S8 in C;
+
+// Species initializations:
+S1 = 5;
+S2 = 5/C;
+S3 = 5*1;
+S4 = 5*C;
+S5 = 5;
+S6 = 5/C;
+S7 = 5*1;
+S8 = 5/C;
+
+// Compartment initializations:
+C = ;
+
+// Other declarations:
+const C;


### PR DESCRIPTION
Since they are always amount, "S1=5" should set the initial amount, not the initial concentration.  Similarly, "S1=5/C" and "S1=5*C" should be handled differently depending on whether the species is set substanceOnly or not.