### PR TITLE
Provide a way to tell Antimony about expat without involving cmake files.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,13 +144,15 @@ if (WITH_LIBSBML_COMPRESSION)
   set(ZLIB_INCLUDE_DIR "${ANT_DEPENDENCIES_INSTALL_PREFIX}/include/")
 endif()
 
-find_package(expat CONFIG REQUIRED)
+if (NOT DEFINED EXPAT_LIBRARY AND NOT DEFINED EXPAT_INCLUDE_DIR)
+    find_package(expat CONFIG REQUIRED)
 
-set(EXPAT_LIBRARY "expat::expat")
-get_target_property(EXPAT_INCLUDE_DIR expat::expat INTERFACE_INCLUDE_DIRECTORIES)
-get_target_property(EXPAT_LIBRARY expat::expat LOCATION)
-message(STATUS "EXPAT_LIBRARY: ${EXPAT_LIBRARY}")
-set(EXPAT_INCLUDE_DIR "${ANT_DEPENDENCIES_INSTALL_PREFIX}/include/")
+    set(EXPAT_LIBRARY "expat::expat")
+    get_target_property(EXPAT_INCLUDE_DIR expat::expat INTERFACE_INCLUDE_DIRECTORIES)
+    get_target_property(EXPAT_LIBRARY expat::expat LOCATION)
+    message(STATUS "EXPAT_LIBRARY: ${EXPAT_LIBRARY}")
+    set(EXPAT_INCLUDE_DIR "${ANT_DEPENDENCIES_INSTALL_PREFIX}/include/")
+endif()
 
 message(STATUS "zlibstatic: ${ZLIB_LIBRARY}")
 


### PR DESCRIPTION
For libantimonyjs, we need to define expat locations without CMake.