### PR TITLE
Deduplicate checkConsistency() calls and fix FBC strict-flag handling

### DIFF
--- a/src/module-sbml.cpp
+++ b/src/module-sbml.cpp
@@ -1740,8 +1740,10 @@ void Module::LoadSBML(Model* sbml)
   LoadLayout(sbml);
 }
 
-void Module::fixFBCStrictIfNeeded()
+void Module::fixFBCStrictIfNeeded(SBMLDocument* doc)
 {
+    // If Finalize()'s checkConsistency() found errors, those errors may be
+    // caused purely by fbc:strict.
     if (!m_hasFBC) {
         return;
     }
@@ -1749,35 +1751,13 @@ void Module::fixFBCStrictIfNeeded()
     if (model == NULL) {
         return;
     }
-    //Set 'strict' to 'false' if need be
-    m_sbml.setConsistencyChecks(LIBSBML_CAT_UNITS_CONSISTENCY, false);
-    m_sbml.setConsistencyChecks(LIBSBML_CAT_IDENTIFIER_CONSISTENCY, false);
-    m_sbml.setConsistencyChecks(LIBSBML_CAT_MATHML_CONSISTENCY, false);
-    m_sbml.setConsistencyChecks(LIBSBML_CAT_SBO_CONSISTENCY, false);
-    m_sbml.setConsistencyChecks(LIBSBML_CAT_OVERDETERMINED_MODEL, false);
-    m_sbml.setConsistencyChecks(LIBSBML_CAT_MODELING_PRACTICE, false);
-    m_sbml.setConsistencyChecks(LIBSBML_CAT_INTERNAL_CONSISTENCY, false);
-    m_sbml.setConsistencyChecks(LIBSBML_CAT_STRICT_UNITS_CONSISTENCY, false);
-    m_sbml.setConsistencyChecks(LIBSBML_CAT_OVERDETERMINED_MODEL, false);
-    m_sbml.setConsistencyChecks(LIBSBML_CAT_OVERDETERMINED_MODEL, false);
-    m_sbml.setConsistencyChecks(LIBSBML_CAT_OVERDETERMINED_MODEL, false);
-    m_sbml.checkConsistency();
-    if (m_sbml.getNumErrors(LIBSBML_SEV_ERROR)) {
-        FbcModelPlugin* fmp = static_cast<FbcModelPlugin*>(model->getPlugin("fbc"));
-        fmp->setStrict(false);
-        m_fbcIsStrict = false;
+    FbcModelPlugin* fmp = static_cast<FbcModelPlugin*>(model->getPlugin("fbc"));
+    if (fmp != NULL) {
+      fmp->setStrict(false);
+      m_fbcIsStrict = false;
+      //Remove the errors from doc; that's what we'll check next for remaining ones.
+      removeFBCStrictErrors(doc);
     }
-    m_sbml.setConsistencyChecks(LIBSBML_CAT_IDENTIFIER_CONSISTENCY, true);
-    m_sbml.setConsistencyChecks(LIBSBML_CAT_MATHML_CONSISTENCY, true);
-    m_sbml.setConsistencyChecks(LIBSBML_CAT_SBO_CONSISTENCY, true);
-    m_sbml.setConsistencyChecks(LIBSBML_CAT_OVERDETERMINED_MODEL, true);
-    m_sbml.setConsistencyChecks(LIBSBML_CAT_MODELING_PRACTICE, true);
-    m_sbml.setConsistencyChecks(LIBSBML_CAT_INTERNAL_CONSISTENCY, true);
-    m_sbml.setConsistencyChecks(LIBSBML_CAT_STRICT_UNITS_CONSISTENCY, true);
-    m_sbml.setConsistencyChecks(LIBSBML_CAT_OVERDETERMINED_MODEL, true);
-    m_sbml.setConsistencyChecks(LIBSBML_CAT_OVERDETERMINED_MODEL, true);
-    m_sbml.setConsistencyChecks(LIBSBML_CAT_OVERDETERMINED_MODEL, true);
-
 }
 
 const SBMLDocument* Module::GetSBML(bool comp)

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -1509,60 +1509,70 @@ bool Module::Finalize()
   if (m_variablename.empty()) {
     //Only test SBML on top-level modules.
     const SBMLDocument* sbmldoc = GetSBML(true); //Use the comp version if possible.
-    //We rely on libsbml's error checking to see if we need to set fbc's 'strict' flag to 'false' or not.
-    fixFBCStrictIfNeeded();
 
     stringstream stream;
-
     SBMLWriter writer;
     writer.writeSBML(sbmldoc, stream);
     string newSBML = stream.str();
     SBMLReader reader;
     SBMLDocument* testdoc = reader.readSBMLFromString(newSBML);
+
+    //To get all errors, need to call both 'readSBMLFromString' and 'checkConsistency()'.
     testdoc->setConsistencyChecks(LIBSBML_CAT_UNITS_CONSISTENCY, false);
     testdoc->checkConsistency();
+    if (testdoc->getNumErrors(LIBSBML_SEV_ERROR)) {
+      fixFBCStrictIfNeeded(testdoc);
+    }
+
     removeBooleanErrors(testdoc);
-    SBMLErrorLog* log = testdoc->getErrorLog();
     string trueerrors = "";
-    for (unsigned int err=0; err<log->getNumErrors(); err++) {
-      const SBMLError* error = log->getError(err);
-      unsigned int errtype = error->getSeverity();
-      switch(errtype) {
-      case 0: //LIBSBML_SEV_INFO:
-        if (m_libsbml_info != "") m_libsbml_info += "\n";
-        m_libsbml_info += error->getMessage();
-        break;
-      case 1: //LIBSBML_SEV_WARNING:
-        if (m_libsbml_warnings != "") m_libsbml_warnings += "\n";
-        m_libsbml_warnings += error->getMessage();
-        break;
-      case 2: //LIBSBML_SEV_ERROR:
-          if (error->getErrorId() >= 10700 && error->getErrorId() <= 10750) {
-              if (m_libsbml_warnings != "") m_libsbml_warnings += "\n";
-              m_libsbml_warnings += error->getMessage();
-          }
-          else {
-              if (trueerrors != "") trueerrors += "\n";
-              trueerrors += error->getMessage();
-          }
-          //  m_libsbml_warnings += error->getMessage(); //If we want to disable fail-on-error again.
-          break;
-      case 3: //LIBSBML_SEV_FATAL:
-        g_registry.SetError("Fatal error when creating an SBML document; unable to continue.  Error from libSBML:\n\n" + error->getMessage());
-        delete testdoc;
-        return true;
-      default:
-        g_registry.SetError("Unknown error when creating an SBML document--there should have only been four types, but we found a fifth?  libSBML may have been updated; try using an older version, perhaps.  Error from libSBML:\n\n" + error->getMessage());
-        delete testdoc;
-        return true;
-      }
+    unsigned int numErrors = testdoc->getErrorLog()->getNumFailsWithSeverity(LIBSBML_SEV_ERROR);
+    if (ProcessSBMLErrorLog(testdoc->getErrorLog(), trueerrors)) {
+      delete testdoc;
+      return true;
     }
     if (trueerrors != "") {
-      g_registry.SetError(SizeTToString(log->getNumFailsWithSeverity(LIBSBML_SEV_ERROR)) + " SBML error(s) when creating module '" + m_modulename + "'.  libAntimony tries to catch these errors before libSBML complains, but sometimes cannot.  Error message(s) from libSBML:\n\n" + trueerrors);
+      g_registry.SetError(SizeTToString(numErrors) + " SBML error(s) when creating module '" + m_modulename + "'.  libAntimony tries to catch these errors before libSBML complains, but sometimes cannot.  Error message(s) from libSBML:\n\n" + trueerrors);
       delete testdoc;
       return true;
     }
     delete testdoc;
+  }
+  return false;
+}
+
+bool Module::ProcessSBMLErrorLog(SBMLErrorLog* log, string& trueerrors)
+{
+  for (unsigned int err=0; err<log->getNumErrors(); err++) {
+    const SBMLError* error = log->getError(err);
+    unsigned int errtype = error->getSeverity();
+    switch(errtype) {
+    case 0: //LIBSBML_SEV_INFO:
+      if (m_libsbml_info != "") m_libsbml_info += "\n";
+      m_libsbml_info += error->getMessage();
+      break;
+    case 1: //LIBSBML_SEV_WARNING:
+      if (m_libsbml_warnings != "") m_libsbml_warnings += "\n";
+      m_libsbml_warnings += error->getMessage();
+      break;
+    case 2: //LIBSBML_SEV_ERROR:
+        if (error->getErrorId() >= 10700 && error->getErrorId() <= 10750) {
+            if (m_libsbml_warnings != "") m_libsbml_warnings += "\n";
+            m_libsbml_warnings += error->getMessage();
+        }
+        else {
+            if (trueerrors != "") trueerrors += "\n";
+            trueerrors += error->getMessage();
+        }
+        //  m_libsbml_warnings += error->getMessage(); //If we want to disable fail-on-error again.
+        break;
+    case 3: //LIBSBML_SEV_FATAL:
+      g_registry.SetError("Fatal error when creating an SBML document; unable to continue.  Error from libSBML:\n\n" + error->getMessage());
+      return true;
+    default:
+      g_registry.SetError("Unknown error when creating an SBML document--there should have only been four types, but we found a fifth?  libSBML may have been updated; try using an older version, perhaps.  Error from libSBML:\n\n" + error->getMessage());
+      return true;
+    }
   }
   return false;
 }

--- a/src/module.h
+++ b/src/module.h
@@ -233,7 +233,8 @@ public:
   void TranslateRulesAndAssignmentsTo(const libsbml::SBase* obj, Variable* var);
   //void  LoadSBML(const SBMLDocument* sbmldoc);
   void  LoadSBML(libsbml::Model* sbml);
-  void  fixFBCStrictIfNeeded();
+  void  fixFBCStrictIfNeeded(libsbml::SBMLDocument* doc);
+  bool  ProcessSBMLErrorLog(libsbml::SBMLErrorLog* log, std::string& trueerrors);
   const libsbml::SBMLDocument* GetSBML(bool comp);
   libsbml::Model* GetModelIfCreated();
   void  CreateSBMLModel(bool comp);

--- a/src/sbmlx.cpp
+++ b/src/sbmlx.cpp
@@ -677,6 +677,42 @@ void removeSBOErrors(SBMLDocument* doc)
     log->removeAll(10720);
 }
 
+void removeFBCStrictErrors(SBMLDocument* doc)
+{
+  SBMLErrorLog* log = doc->getErrorLog();
+#if LIBSBML_VERSION >= 51103
+  log->removeAll(2020608);
+  log->removeAll(2020707);
+  log->removeAll(2020708);
+  log->removeAll(2020709);
+  log->removeAll(2020710);
+  log->removeAll(2020711);
+  log->removeAll(2020712);
+  log->removeAll(2020713);
+  log->removeAll(2020714);
+  log->removeAll(2020715);
+  log->removeAll(2020716);
+#else
+  log->remove(2020608);
+  log->remove(2020707);
+  log->remove(2020708);
+  log->remove(2020709);
+  log->remove(2020710);
+  log->remove(2020711);
+  log->remove(2020712);
+  log->remove(2020713);
+  log->remove(2020714);
+  log->remove(2020715);
+  log->remove(2020716);
+#endif
+  if (log->contains(1090105) && log->getNumFailsWithSeverity(LIBSBML_SEV_ERROR) == 1) {
+    log->remove(1090105);
+  }
+  if (log->contains(1090106) && log->getNumFailsWithSeverity(LIBSBML_SEV_WARNING) == 1) {
+    log->remove(1090106);
+  }
+}
+
 void elideMetaIds(SBMLDocument* doc)
 {
   List* elts = doc->getAllElements();

--- a/src/sbmlx.h
+++ b/src/sbmlx.h
@@ -32,6 +32,7 @@ UnitDef GetUnitDefFrom(const libsbml::UnitDefinition* unitdefinition, std::strin
 
 void removeBooleanErrors(libsbml::SBMLDocument* doc);
 void removeSBOErrors(libsbml::SBMLDocument* doc);
+void removeFBCStrictErrors(libsbml::SBMLDocument* doc);
 
 /// Remove all metaids from document - allows comparisons without metaids
 void elideMetaIds(libsbml::SBMLDocument* doc);

--- a/src/test/TestAntimonyFBC.cpp
+++ b/src/test/TestAntimonyFBC.cpp
@@ -10,6 +10,7 @@
 #include <sbml/SBMLTypes.h>
 #include <sbml/conversion/SBMLConverterRegistry.h>
 #include <sbml/packages/comp/common/CompExtensionTypes.h>
+#include <sbml/packages/fbc/common/FbcExtensionTypes.h>
 
 #include <string>
 #include "gtest/gtest.h"
@@ -80,6 +81,31 @@ TEST(AntimonyFBC, test_simple_flux)
 {
   compareFBCAnt("simple_flux");
   compareFBCSBML("simple_flux");
+}
+
+TEST(AntimonyFBC, test_simple_flux_comp_strict)
+{
+  //Regression test:  ensure that strict=false even in comp version.
+  clearPreviousLoads();
+  g_registry.SetCC("__");
+  string dir(TestDataDirectory);
+  string filename = dir + "fbc/simple_flux.txt";
+  long ret = loadAntimonyFile(filename.c_str());
+  EXPECT_TRUE(ret != -1);
+
+  char* compsbml = getCompSBMLString(NULL);
+  ASSERT_TRUE(compsbml != NULL);
+
+  SBMLDocument* doc = readSBMLFromString(compsbml);
+  ASSERT_TRUE(doc != NULL);
+  Model* model = doc->getModel();
+  ASSERT_TRUE(model != NULL);
+  FbcModelPlugin* fmp = static_cast<FbcModelPlugin*>(model->getPlugin("fbc"));
+  ASSERT_TRUE(fmp != NULL);
+  EXPECT_FALSE(fmp->getStrict());
+
+  delete doc;
+  freeAll();
 }
 
 TEST(AntimonyFBC, test_simple_flux2)


### PR DESCRIPTION
Only call checkConsistency() once on the reproduced model in Finalize, and don't call it yet again if we have FBC:strict errors; just remove them and flip the flag.