### PR TITLE
Notes html cache

### DIFF
--- a/src/annotated.cpp
+++ b/src/annotated.cpp
@@ -14,6 +14,7 @@ Annotated::Annotated()
     , m_model_quals()
     , m_biol_quals()
     , m_notes()
+    , m_notesHTML()
     , m_created()
     , m_modified()
     , m_history()
@@ -48,6 +49,12 @@ bool Annotated::TransferAnnotationTo(SBase* sbmlobj, string metaid) const
   }
   if (!m_notes.empty()) {
       sbmlobj->setMetaId(metaid);
+      bool usedCachedHTML = false;
+      if (!m_notesHTML.empty()) {
+          int ret = sbmlobj->setNotes(m_notesHTML, false);
+          usedCachedHTML = (ret == libsbml::LIBSBML_OPERATION_SUCCESS);
+      }
+      if (!usedCachedHTML) {
       string notes = getNotesString();
       if (notes[0] == '<') {
           int ret = sbmlobj->setNotes(notes, false);
@@ -70,6 +77,11 @@ bool Annotated::TransferAnnotationTo(SBase* sbmlobj, string metaid) const
           regex triple_quotes("\"\"\"");
           notes = regex_replace(notes, triple_quotes, "```");
           sbmlobj->setNotesFromMarkdown(notes);
+          // Cache the generated HTML so a subsequent TransferAnnotationTo
+          // call for this same object (e.g. the comp=false build after the
+          // comp=true one) can skip the markdown conversion entirely.
+          m_notesHTML = sbmlobj->getNotesString();
+      }
       }
   }
   ModelHistory* mh = const_cast<ModelHistory*>(&m_history);
@@ -170,9 +182,20 @@ void Annotated::ReadAnnotationFrom(const SBase* sbmlobj)
     m_sboTerm = sbmlobj->getSBOTerm();
   }
   if (sbmlobj->isSetNotes()) {
+      bool wasFirstNotes = m_notes.empty();
       string notes = sbmlobj->getNotesMarkdown();
       trimAndRemoveDoubleSpaces(notes);
       m_notes.push_back(notes);
+      if (wasFirstNotes) {
+          // Stash the original HTML so TransferAnnotationTo can reuse it
+          // verbatim instead of re-deriving it from markdown.
+          m_notesHTML = sbmlobj->getNotesString();
+      }
+      else {
+          // m_notes is now more than one fragment; the cached HTML (if any)
+          // no longer corresponds to the combined text.
+          m_notesHTML.clear();
+      }
   }
   if (sbmlobj->isSetModelHistory()) {
       m_history = *sbmlobj->getModelHistory();
@@ -314,6 +337,10 @@ void Annotated::AppendNotes(const std::vector<std::string>& resources)
     for (size_t r = 0; r < resources.size(); r++) {
         if (!resources[r].empty()) {
             m_notes.push_back(resources[r]);
+            // The notes are being set independently of reading SBML (e.g.
+            // from an Antimony script), so any cached HTML no longer
+            // corresponds to the current text.
+            m_notesHTML.clear();
         }
     }
 }
@@ -641,6 +668,7 @@ bool Annotated::Synchronize(Variable * clone, const Variable * conversionFactor)
   if (!m_notes.empty()) {
       if (clone->m_notes.empty()) {
           clone->m_notes = m_notes;
+          clone->m_notesHTML = m_notesHTML;
       }
   }
 

--- a/src/annotated.h
+++ b/src/annotated.h
@@ -18,13 +18,7 @@ BiolQualsType m_biol_quals;
 std::vector < std::string> m_notes;
 // Cache of the HTML/XHTML notes corresponding to m_notes, so that
 // TransferAnnotationTo doesn't have to redo an expensive markdown->HTML
-// conversion every time it's called for the same object (e.g. once for the
-// comp=true SBML build and once for comp=false). Populated either from the
-// original SBML on ReadAnnotationFrom, or from the first markdown
-// conversion done by TransferAnnotationTo. Cleared whenever m_notes is set
-// independently of a single SBML notes element (i.e. AppendNotes, used when
-// parsing an Antimony script), since it would no longer correspond to the
-// text in m_notes.
+// conversion every time it's called.
 mutable std::string m_notesHTML;
 libsbml::Date m_created;
 std::vector<libsbml::Date> m_modified;

--- a/src/annotated.h
+++ b/src/annotated.h
@@ -16,6 +16,16 @@ ModelQualsType m_model_quals;
 typedef std::vector< std::pair<libsbml::BiolQualifierType_t,  std::vector<std::string> > > BiolQualsType;
 BiolQualsType m_biol_quals;
 std::vector < std::string> m_notes;
+// Cache of the HTML/XHTML notes corresponding to m_notes, so that
+// TransferAnnotationTo doesn't have to redo an expensive markdown->HTML
+// conversion every time it's called for the same object (e.g. once for the
+// comp=true SBML build and once for comp=false). Populated either from the
+// original SBML on ReadAnnotationFrom, or from the first markdown
+// conversion done by TransferAnnotationTo. Cleared whenever m_notes is set
+// independently of a single SBML notes element (i.e. AppendNotes, used when
+// parsing an Antimony script), since it would no longer correspond to the
+// text in m_notes.
+mutable std::string m_notesHTML;
 libsbml::Date m_created;
 std::vector<libsbml::Date> m_modified;
 libsbml::ModelHistory m_history;


### PR DESCRIPTION
Speedup fix:  it takes significant processing to convert markdown to and from HTML, and also the conversions are not always perfect.  So once we have an HTML version, keep it and use it again when requested.