### PR TITLE
Allow kinetic law annotations being set directly.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -401,6 +401,7 @@ file(GLOB LIBANTIMONY_SOURCES
     ${ANTIMONY_SRC_DIR}dnastrand.cpp
     ${ANTIMONY_SRC_DIR}event.cpp
     ${ANTIMONY_SRC_DIR}formula.cpp
+    ${ANTIMONY_SRC_DIR}kineticLawWrapper.cpp
     ${ANTIMONY_SRC_DIR}layoutWrapper.cpp
     ${ANTIMONY_SRC_DIR}module.cpp
     ${ANTIMONY_SRC_DIR}reactantlist.cpp
@@ -439,6 +440,7 @@ file(GLOB LIBANTIMONY_HEADERS
         ${ANTIMONY_SRC_DIR}enums.h
         ${ANTIMONY_SRC_DIR}event.h
         ${ANTIMONY_SRC_DIR}formula.h
+        ${ANTIMONY_SRC_DIR}kineticLawWrapper.h
         ${ANTIMONY_SRC_DIR}layoutWrapper.h
         ${ANTIMONY_SRC_DIR}libutil.h
         ${ANTIMONY_SRC_DIR}module.h

--- a/src/antimony_api.cpp
+++ b/src/antimony_api.cpp
@@ -1739,6 +1739,7 @@ LIB_EXTERN return_type getTypeOfSymbol(const char* moduleName, const char* symbo
   case varUncertWrapper:
   case varLayoutWrapper:
   case varLayoutColorEtc:
+  case varKineticLawWrapper:
       return allUnknown;
   case varModule:
     return subModules;

--- a/src/enums.h
+++ b/src/enums.h
@@ -38,6 +38,7 @@ enum rd_type {rdBecomes = 0, rdActivates, rdInhibits, rdInfluences, rdBecomesIrr
  * - varGeneProductAssociation: A gene product association (as defined in the FBC package)
  * - varSpeciesCharge: The charge of a species (defined in the FBC package)
  * - varSpeciesChemicalFormula: The chemical formula of a species (defined in the FBC package)
+ * - varKineticLawWrapper: The <kineticLaw> sub-object of a reaction, addressed as 'reaction.kineticLaw' (used to set its sboTerm, annotations, etc. separately from the reaction itself)
  */
 
 enum var_type {varSpeciesUndef = 0,
@@ -65,6 +66,7 @@ enum var_type {varSpeciesUndef = 0,
                varGeneProductAssociation,
                varSpeciesCharge,
                varSpeciesChemicalFormula,
+               varKineticLawWrapper,
                };
 /**
  * return_types are used in the API when requesting information about different symbols.  Each return_type refers to a different group of symbols, and are overlapping--i.e. a single symbol can be included in 'allGenes' and 'allReactions'. 

--- a/src/kineticLawWrapper.cpp
+++ b/src/kineticLawWrapper.cpp
@@ -1,0 +1,61 @@
+#include "kineticLawWrapper.h"
+#include "module.h"
+#include "registry.h"
+
+using namespace std;
+
+KineticLawWrapper::KineticLawWrapper(Variable* parent)
+  : Variable()
+  , m_parent(parent)
+{
+  m_module = parent->GetNamespace();
+  m_displayname = "";
+  m_formulatype = formulaINITIAL;
+  m_supercomptype = varUndefined;
+  m_deletedunit = false;
+  m_replacedformrxn = false;
+  m_const = constDEFAULT;
+  m_substOnly = false;
+  m_sboTermWrapper = NULL;
+  m_type = varKineticLawWrapper;
+  SetNamespace(parent->GetNamespace());
+}
+
+KineticLawWrapper::~KineticLawWrapper()
+{
+}
+
+bool KineticLawWrapper::IsPointer() const
+{
+  return false;
+}
+
+bool KineticLawWrapper::SetFormula(Formula* formula, bool isObjective)
+{
+  return m_parent->SetFormula(formula, isObjective);
+}
+
+bool KineticLawWrapper::SetType(var_type newtype)
+{
+  if (newtype == m_type) {
+    return false;
+  }
+  g_registry.SetError("Unable to use the symbol '" + GetNameDelimitedBy(".") + "' in any context other than setting properties of a kinetic law.");
+  return true;
+}
+
+Variable* KineticLawWrapper::GetParent()
+{
+  return m_parent;
+}
+
+string KineticLawWrapper::GetNameDelimitedBy(string cc) const
+{
+  return m_parent->GetNameDelimitedBy(cc) + cc + "kineticLaw";
+}
+
+bool KineticLawWrapper::Synchronize(Variable* clone, const Variable* conversionFactor)
+{
+  g_registry.SetError("Unable to synchronize two symbols when one of them ('" + GetNameDelimitedBy(".") + "') is a kinetic law.");
+  return true;
+}

--- a/src/kineticLawWrapper.h
+++ b/src/kineticLawWrapper.h
@@ -1,0 +1,26 @@
+#ifndef KINETICLAWWRAPPER_H
+#define KINETICLAWWRAPPER_H
+
+#include "variable.h"
+
+class Variable;
+// A proxy class returned by the parser for annotating a reaction's kinetic
+// law (sboTerm, CV terms, notes, etc.) separately from the reaction itself.
+class KineticLawWrapper : public Variable
+{
+protected:
+  Variable* m_parent;
+public:
+  KineticLawWrapper(Variable* parent);
+  ~KineticLawWrapper();
+
+  bool IsPointer() const;
+  virtual bool SetFormula(Formula* formula, bool isObjective=false);
+  virtual bool SetType(var_type newtype);
+  Variable* GetParent();
+  virtual std::string GetNameDelimitedBy(std::string cc) const;
+  virtual bool Synchronize(Variable* clone, const Variable* conversionFactor);
+};
+
+
+#endif //KINETICLAWWRAPPER_H

--- a/src/module-cellml.cpp
+++ b/src/module-cellml.cpp
@@ -563,6 +563,7 @@ void Module::CreateCellMLComponent(Module* topmod)
     case varSboTermWrapper:
     case varStoichiometry:
     case varLayoutColorEtc:
+    case varKineticLawWrapper:
         //These all have no CellML equivalent (except Module, which is taken care of separately).
       break;
     case varAlgebraicRule:

--- a/src/module-sbml.cpp
+++ b/src/module-sbml.cpp
@@ -1,4 +1,5 @@
 #include "module.h"
+#include "kineticLawWrapper.h"
 #include "sbml/Model.h"
 #include <sbmlnetwork/libsbmlnetwork_sbmldocument.h>
 #include <sbmlnetwork/libsbmlnetwork_sbmldocument_layout.h>
@@ -288,6 +289,7 @@ void Module::FindOrCreateLocalVersionOf(const Variable* var, libsbml::Model* sbm
   case varSboTermWrapper:
   case varUncertWrapper:
   case varLayoutWrapper:
+  case varKineticLawWrapper:
   case varConstraint:
   case varStoichiometry:
   case varAlgebraicRule:
@@ -1609,6 +1611,15 @@ void Module::LoadSBML(Model* sbml)
     }
     //Put reactants, products, and the formula together:
     Variable* arxn = AddNewReaction(reactants, rxntype, products, &formula, var);
+    if (reaction->isSetKineticLaw()) {
+      const KineticLaw* kl = reaction->getKineticLaw();
+      if (kl->isSetSBOTerm() || kl->getNumCVTerms() > 0 || kl->isSetNotes() || kl->isSetMetaId()) {
+        string kineticLawStr = "kineticLaw";
+        KineticLawWrapper* klw = static_cast<KineticLawWrapper*>(arxn->GetSubVariable(&kineticLawStr));
+        klw->PopulateCVTerms((SBase*)kl);
+        klw->ReadAnnotationFrom(kl);
+      }
+    }
     if (reaction->isSetCompartment()) {
       if (defaultcompartments.find(reaction->getCompartment()) == defaultcompartments.end()) {
         Variable* compartment = AddOrFindVariable(&(reaction->getCompartment()));
@@ -2403,13 +2414,19 @@ void Module::CreateSBMLModel(bool comp)
     }
     const Formula* formula = reaction->GetFormula();
     string formstring = formula->ToSBMLString(rxnvar->GetStrandVars());
-    if (!formula->IsEmpty()) {
+    const KineticLawWrapper* klw = rxnvar->GetKineticLawWrapper();
+    if (!formula->IsEmpty() || klw != NULL) {
       KineticLaw* kl = sbmlmod->createKineticLaw();
-      ASTNode* math = parseStringToASTNode(formstring);
-      kl->setMath(math);
-      delete math;
-      if (comp) {
-        formula->AddReferencedVariablesTo(referencedVars);
+      if (!formula->IsEmpty()) {
+        ASTNode* math = parseStringToASTNode(formstring);
+        kl->setMath(math);
+        delete math;
+        if (comp) {
+          formula->AddReferencedVariablesTo(referencedVars);
+        }
+      }
+      if (klw != NULL) {
+        klw->TransferAnnotationTo(kl, GetModuleName()+"."+klw->GetNameDelimitedBy(cc));
       }
     }
     for (int lr = 0; lr < 2; lr++) {
@@ -4085,6 +4102,7 @@ void Module::LoadLayout(Model* sbml)
             case varInteraction:
             case varUndefined:
             case varSboTermWrapper:
+            case varKineticLawWrapper:
             case varUncertWrapper:
             case varLayoutColorEtc:
             case varModule:

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -858,6 +858,7 @@ void Module::AddDefaultInitialValues()
     case varSboTermWrapper:
     case varUncertWrapper:
     case varLayoutWrapper:
+    case varKineticLawWrapper:
     case varConstraint:
     case varAlgebraicRule:
     case varLayoutColorEtc:
@@ -1305,6 +1306,7 @@ bool Module::Finalize()
           case varUnitDefinition:
           case varDeleted:
           case varConstraint:
+          case varKineticLawWrapper:
           case varSboTermWrapper:
           case varUncertWrapper:
           case varStoichiometry:
@@ -1761,6 +1763,7 @@ bool Module::AreEquivalent(return_type rtype, var_type vtype) const
   case varSboTermWrapper:
   case varUncertWrapper:
   case varLayoutWrapper:
+  case varKineticLawWrapper:
   case varConstraint:
   case varStoichiometry:
   case varAlgebraicRule:
@@ -2341,6 +2344,7 @@ string Module::GetAntimony(set<const Module*>& usedmods, bool funcsincluded, boo
     case varSboTermWrapper:
     case varUncertWrapper:
     case varLayoutWrapper:
+    case varKineticLawWrapper:
     case varConstraint:
     case varStoichiometry:
     case varAlgebraicRule:
@@ -2431,6 +2435,7 @@ string Module::GetAntimony(set<const Module*>& usedmods, bool funcsincluded, boo
       bool anysboterm = false;
       for (size_t var = 0; var < m_uniquevars.size(); var++) {
           string sboterms = m_uniquevars[var]->CreateSBOTermsAntimonySyntax(m_uniquevars[var]->GetNameDelimitedBy(cc), indent, "sboTerm");
+          sboterms += m_uniquevars[var]->CreateKineticLawSBOTermAntimonySyntax(indent, cc);
           if (anysboterm == false && sboterms.size() > 0) {
               retval += "\n" + indent + "// SBO terms:\n";
               anysboterm = true;
@@ -2446,6 +2451,7 @@ string Module::GetAntimony(set<const Module*>& usedmods, bool funcsincluded, boo
       bool anycvterm = false;
       for (size_t var = 0; var < m_uniquevars.size(); var++) {
           string cvterms = m_uniquevars[var]->CreateCVTermsAntimonySyntax(m_uniquevars[var]->GetNameDelimitedBy(cc), indent);
+          cvterms += m_uniquevars[var]->CreateKineticLawCVTermsAntimonySyntax(indent, cc);
           if (anycvterm == false && cvterms.size() > 0) {
               retval += "\n" + indent + "// CV terms:\n";
               anycvterm = true;
@@ -3036,6 +3042,7 @@ void Module::Convert(Variable* conv, Variable* cf, string modulename)
     case varSboTermWrapper:
     case varUncertWrapper:
     case varLayoutWrapper:
+    case varKineticLawWrapper:
     case varLayoutColorEtc:
     case varSpeciesChemicalFormula:
       break;
@@ -3080,6 +3087,7 @@ void Module::ConvertTime(Variable* tcf)
     case varSboTermWrapper:
     case varUncertWrapper:
     case varLayoutWrapper:
+    case varKineticLawWrapper:
     case varLayoutColorEtc:
     case varGeneProduct:
     case varGeneProductAssociation:
@@ -3118,6 +3126,7 @@ void Module::ConvertExtent(Variable* xcf)
     case varSboTermWrapper:
     case varUncertWrapper:
     case varLayoutWrapper:
+    case varKineticLawWrapper:
     case varConstraint:
     case varStoichiometry:
     case varAlgebraicRule:
@@ -3166,6 +3175,7 @@ void Module::UndoTimeExtentConversions(Variable* tcf, Variable* xcf)
     case varSboTermWrapper:
     case varUncertWrapper:
     case varLayoutWrapper:
+    case varKineticLawWrapper:
     case varLayoutColorEtc:
     case varGeneProduct:
     case varGeneProductAssociation:

--- a/src/test/TestAntimonyBasic.cpp
+++ b/src/test/TestAntimonyBasic.cpp
@@ -467,3 +467,8 @@ TEST(AntimonyBasic, test_floating_species_in_rate_rule)
   compareFileTranslation("floating_species_in_rate_rule");
 }
 
+TEST(AntimonyBasic, test_kineticLaw_set_formula)
+{
+  compareFileTranslation("kl_set_formula");
+}
+

--- a/src/test/TestAntimonyCVTerms.cpp
+++ b/src/test/TestAntimonyCVTerms.cpp
@@ -359,3 +359,13 @@ TEST(AntimonyCVTerms, test_creator_two_model_internal)
 {
     compareStringTranslation("model foo(); a=3; model creator.givenName \"Lucian\"; model creator.familyName \"Smith\"; model creator.organization \"UW\"; model creator.email \"lpsmith@uw.edu\";model creator2.name \"George Holtzour\"; model creator2.organization \"Family lore\"; model creator2.email \"george@theholtz.net\"; end", "creator_two_model.xml");
 }
+
+TEST(AntimonyCVTerms, test_kineticLaw_hasVersion_txt)
+{
+  compareStringTranslation("J0.kineticLaw hasVersion \"BQB_thing\";J0: ->A;;", "kl_hasVersion.xml");
+}
+
+TEST(AntimonyCVTerms, test_kineticLaw_hasVersion)
+{
+  compareFileTranslation("kl_hasVersion");
+}

--- a/src/test/TestAntimonySBO.cpp
+++ b/src/test/TestAntimonySBO.cpp
@@ -108,6 +108,14 @@ TEST(AntimonySBO, test_SBO_reaction)
   compareFileTranslation("SBO_reaction");
 }
 
+TEST(AntimonySBO, test_SBO_kineticLaw_txt)
+{
+  // https://github.com/sys-bio/antimony/issues/87 : sboTerm (and other
+  // annotations) on a reaction's kinetic law, separately from the reaction
+  // itself.
+  compareStringTranslation("J0: A -> ; k1*A; J0.kineticLaw.sboTerm = 46", "SBO_kineticLaw.xml");
+}
+
 TEST(AntimonySBO, test_SBO_event_txt)
 {
   compareStringTranslation("E0: at(time>3): b=4; E0.sboTerm=901", "SBO_event.xml");

--- a/src/test/test-data/SBO_kineticLaw.xml
+++ b/src/test/test-data/SBO_kineticLaw.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
+  <model metaid="__main" id="__main">
+    <listOfCompartments>
+      <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
+    </listOfCompartments>
+    <listOfSpecies>
+      <species id="A" compartment="default_compartment" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+    </listOfSpecies>
+    <listOfParameters>
+      <parameter id="k1" constant="true"/>
+    </listOfParameters>
+    <listOfReactions>
+      <reaction id="J0" reversible="true">
+        <listOfReactants>
+          <speciesReference species="A" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <kineticLaw sboTerm="SBO:0000046">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> k1 </ci>
+              <ci> A </ci>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+    </listOfReactions>
+  </model>
+</sbml>

--- a/src/test/test-data/kl_hasVersion.txt
+++ b/src/test/test-data/kl_hasVersion.txt
@@ -1,0 +1,2 @@
+J0.kineticLaw hasVersion "BQB_thing"
+J0: ->A;

--- a/src/test/test-data/kl_hasVersion.xml
+++ b/src/test/test-data/kl_hasVersion.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created by libAntimony version v3.1.3 with libSBML version 5.21.1. -->
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
+  <model metaid="__main" id="__main">
+    <listOfCompartments>
+      <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
+    </listOfCompartments>
+    <listOfSpecies>
+      <species id="A" compartment="default_compartment" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+    </listOfSpecies>
+    <listOfReactions>
+      <reaction id="J0" reversible="true">
+        <listOfProducts>
+          <speciesReference species="A" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <kineticLaw metaid="__main.J0_kineticLaw">
+          <annotation>
+            <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+              <rdf:Description rdf:about="#__main.J0_kineticLaw">
+                <bqbiol:hasVersion>
+                  <rdf:Bag>
+                    <rdf:li rdf:resource="BQB_thing"/>
+                  </rdf:Bag>
+                </bqbiol:hasVersion>
+              </rdf:Description>
+            </rdf:RDF>
+          </annotation>
+        </kineticLaw>
+      </reaction>
+    </listOfReactions>
+  </model>
+</sbml>

--- a/src/test/test-data/kl_hasVersion_rt.txt
+++ b/src/test/test-data/kl_hasVersion_rt.txt
@@ -1,0 +1,12 @@
+// Created by libAntimony v3.1.3
+// Compartments and Species:
+species A;
+
+// Reactions:
+J0:  -> A; ;
+
+// Species initializations:
+A = ;
+
+// CV terms:
+J0.kineticLaw hasVersion "BQB_thing"

--- a/src/test/test-data/kl_set_formula.txt
+++ b/src/test/test-data/kl_set_formula.txt
@@ -1,0 +1,2 @@
+J0: A->;
+J0.kineticLaw = 5*A

--- a/src/test/test-data/kl_set_formula.xml
+++ b/src/test/test-data/kl_set_formula.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created by libAntimony version v3.1.3 with libSBML version 5.21.1. -->
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" level="3" version="2" comp:required="true">
+  <model metaid="__main" id="__main">
+    <listOfCompartments>
+      <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
+    </listOfCompartments>
+    <listOfSpecies>
+      <species id="A" compartment="default_compartment" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+    </listOfSpecies>
+    <listOfReactions>
+      <reaction id="J0" reversible="true">
+        <listOfReactants>
+          <speciesReference species="A" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <cn type="integer"> 5 </cn>
+              <ci> A </ci>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+    </listOfReactions>
+  </model>
+</sbml>

--- a/src/test/test-data/kl_set_formula_rt.txt
+++ b/src/test/test-data/kl_set_formula_rt.txt
@@ -1,0 +1,9 @@
+// Created by libAntimony v3.1.3
+// Compartments and Species:
+species A;
+
+// Reactions:
+J0: A -> ; 5*A;
+
+// Species initializations:
+A = ;

--- a/src/typex.cpp
+++ b/src/typex.cpp
@@ -32,6 +32,7 @@ bool IsReaction(const var_type vtype)
   case varSboTermWrapper:
   case varUncertWrapper:
   case varLayoutWrapper:
+  case varKineticLawWrapper:
   case varStoichiometry:
   case varAlgebraicRule:
   case varLayoutColorEtc:
@@ -82,6 +83,7 @@ bool IsSpecies(const var_type vtype)
   case varSboTermWrapper:
   case varUncertWrapper:
   case varLayoutWrapper:
+  case varKineticLawWrapper:
   case varStoichiometry:
   case varAlgebraicRule:
   case varLayoutColorEtc:
@@ -117,6 +119,7 @@ bool IsDNA(const var_type vtype)
   case varSboTermWrapper:
   case varUncertWrapper:
   case varLayoutWrapper:
+  case varKineticLawWrapper:
   case varStoichiometry:
   case varAlgebraicRule:
   case varLayoutColorEtc:
@@ -154,6 +157,7 @@ bool CanHaveRateRule(const var_type vtype)
   case varSboTermWrapper:
   case varUncertWrapper:
   case varLayoutWrapper:
+  case varKineticLawWrapper:
   case varAlgebraicRule:
   case varGeneProduct:
   case varGeneProductAssociation:
@@ -189,6 +193,7 @@ bool CanHaveAssignmentRule(const var_type vtype)
   case varSboTermWrapper:
   case varUncertWrapper:
   case varLayoutWrapper:
+  case varKineticLawWrapper:
   case varAlgebraicRule:
   case varGeneProduct:
   case varGeneProductAssociation:
@@ -225,6 +230,7 @@ bool CanHaveAlgebraicRule(const var_type vtype)
     case varSboTermWrapper:
     case varUncertWrapper:
     case varLayoutWrapper:
+    case varKineticLawWrapper:
     case varGeneProduct:
     case varGeneProductAssociation:
     case varSpeciesCharge:
@@ -258,6 +264,7 @@ bool CanBeInReaction(const var_type vtype)
   case varSboTermWrapper:
   case varUncertWrapper:
   case varLayoutWrapper:
+  case varKineticLawWrapper:
   case varStoichiometry:
   case varAlgebraicRule:
   case varGeneProduct:
@@ -294,6 +301,7 @@ bool CanBeStoichiometry(const var_type vtype)
     case varSboTermWrapper:
     case varUncertWrapper:
     case varLayoutWrapper:
+    case varKineticLawWrapper:
     case varAlgebraicRule:
     case varGeneProduct:
     case varGeneProductAssociation:
@@ -332,6 +340,7 @@ bool HasOrIsFormula(const var_type vtype)
   case varSboTermWrapper:
   case varUncertWrapper:
   case varLayoutWrapper:
+  case varKineticLawWrapper:
   case varAlgebraicRule: //Again, not for Jarnac, which doesn't do algebraic rules.
   case varSpeciesChemicalFormula:
     return false;
@@ -455,6 +464,8 @@ string VarTypeToString(const var_type vtype)
     return "Uncertainty parameter";
   case varLayoutWrapper:
       return "Layout or render parameter";
+  case varKineticLawWrapper:
+      return "Kinetic law annotation";
   case varStoichiometry:
       return "Stoichiometry";
   case varAlgebraicRule:

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -6,6 +6,7 @@
 #include "sbmlx.h"
 #include "sboTermWrapper.h"
 #include "layoutWrapper.h"
+#include "kineticLawWrapper.h"
 #include "stringx.h"
 #include "typex.h"
 #include "unitdef.h"
@@ -46,7 +47,8 @@ Variable::Variable(const string name, const Module* module)
     m_const(constDEFAULT),
     m_substOnly(false),
     m_unitVariable(),
-    m_sboTermWrapper(NULL)
+    m_sboTermWrapper(NULL),
+    m_kineticLawWrapper(NULL)
 {
   m_name.push_back(name);
 }
@@ -70,6 +72,7 @@ Variable::Variable(const Variable& other)
     m_deletions(other.m_deletions),
     m_type(other.m_type),
     m_sboTermWrapper(NULL),
+    m_kineticLawWrapper(NULL),
     m_compartment(other.m_compartment),
     m_supercompartment(other.m_supercompartment),
     m_supercomptype(other.m_supercomptype),
@@ -89,6 +92,8 @@ Variable::~Variable()
 {
   if (m_sboTermWrapper)
     delete m_sboTermWrapper;
+  if (m_kineticLawWrapper)
+    delete m_kineticLawWrapper;
   for (size_t uw = 0; uw < m_uncertWrappers.size(); uw++) {
     delete m_uncertWrappers[uw];
   }
@@ -173,6 +178,7 @@ formula_type Variable::GetFormulaType() const
   case varSboTermWrapper:
   case varUncertWrapper:
   case varLayoutWrapper:
+  case varKineticLawWrapper:
   case varLayoutColorEtc:
   case varGeneProduct:
   case varGeneProductAssociation:
@@ -199,6 +205,7 @@ const Formula* Variable::GetFormula() const
   case varUnitDefinition:
   case varUncertWrapper:
   case varLayoutWrapper:
+  case varKineticLawWrapper:
   case varStoichiometry:
   case varAlgebraicRule:
   case varGeneProduct:
@@ -245,6 +252,7 @@ Formula* Variable::GetFormula()
   case varUnitDefinition:
   case varUncertWrapper:
   case varLayoutWrapper:
+  case varKineticLawWrapper:
   case varStoichiometry:
   case varAlgebraicRule:
   case varGeneProduct:
@@ -299,6 +307,7 @@ const Formula* Variable::GetInitialAssignment() const
   case varUnitDefinition:
   case varUncertWrapper:
   case varLayoutWrapper:
+  case varKineticLawWrapper:
       return &(m_valFormula);
   case varFormulaOperator:
   case varDNA:
@@ -355,6 +364,7 @@ const Formula* Variable::GetAssignmentRuleOrKineticLaw() const
   case varSboTermWrapper:
   case varUncertWrapper:
   case varLayoutWrapper:
+  case varKineticLawWrapper:
   case varLayoutColorEtc:
   case varAlgebraicRule:
   case varGeneProduct:
@@ -401,6 +411,7 @@ Formula* Variable::GetAssignmentRuleOrKineticLaw()
   case varSboTermWrapper:
   case varUncertWrapper:
   case varLayoutWrapper:
+  case varKineticLawWrapper:
   case varLayoutColorEtc:
   case varAlgebraicRule:
   case varGeneProduct:
@@ -550,6 +561,15 @@ Variable* Variable::GetSubVariable(const string* name)
       return NULL;
     }
     return this;
+  }
+  if (name && CaselessStrCmp(true, *name, "kineticLaw")) {
+    if (SetType(varReactionUndef)) {
+      g_registry.SetError("The element " + GetNameDelimitedBy(".") + " cannot have a kinetic law, because it is set to be a " + VarTypeToString(m_type) + ".");
+      return NULL;
+    }
+    if (!m_kineticLawWrapper)
+      m_kineticLawWrapper = new KineticLawWrapper(this);
+    return m_kineticLawWrapper;
   }
   Module* mod = g_registry.GetModule(m_module);
   if (IsReaction(m_type)) {
@@ -728,6 +748,7 @@ bool Variable::GetIsConst() const
   case varSboTermWrapper:
   case varUncertWrapper:
   case varLayoutWrapper:
+  case varKineticLawWrapper:
   case varLayoutColorEtc:
   case varGeneProduct:
   case varGeneProductAssociation:
@@ -947,6 +968,7 @@ bool Variable::SetType(var_type newtype)
     case varSboTermWrapper:
     case varUncertWrapper:
     case varLayoutWrapper:
+    case varKineticLawWrapper:
     case varStoichiometry:
     case varAlgebraicRule:
     case varGeneProduct:
@@ -993,6 +1015,7 @@ bool Variable::SetType(var_type newtype)
     case varSboTermWrapper:
     case varUncertWrapper:
     case varLayoutWrapper:
+    case varKineticLawWrapper:
     case varSpeciesChemicalFormula:
       g_registry.SetError(error); return true;
     case varLayoutColorEtc:
@@ -1025,6 +1048,7 @@ bool Variable::SetType(var_type newtype)
     case varSboTermWrapper:
     case varUncertWrapper:
     case varLayoutWrapper:
+    case varKineticLawWrapper:
     case varStoichiometry:
     case varAlgebraicRule:
     case varGeneProduct:
@@ -1056,6 +1080,7 @@ bool Variable::SetType(var_type newtype)
     case varUncertWrapper:
     case varStoichiometry:
     case varLayoutWrapper:
+    case varKineticLawWrapper:
     case varAlgebraicRule:
     case varGeneProduct:
     case varGeneProductAssociation:
@@ -1085,6 +1110,7 @@ bool Variable::SetType(var_type newtype)
     case varSboTermWrapper:
     case varUncertWrapper:
     case varLayoutWrapper:
+    case varKineticLawWrapper:
     case varStoichiometry:
     case varAlgebraicRule:
     case varGeneProduct:
@@ -1117,6 +1143,7 @@ bool Variable::SetType(var_type newtype)
     case varSboTermWrapper:
     case varUncertWrapper:
     case varLayoutWrapper:
+    case varKineticLawWrapper:
     case varStoichiometry:
     case varAlgebraicRule:
     case varGeneProduct:
@@ -1148,6 +1175,7 @@ bool Variable::SetType(var_type newtype)
   case varSboTermWrapper:
   case varUncertWrapper:
   case varLayoutWrapper:
+  case varKineticLawWrapper:
   case varAlgebraicRule:
   case varGeneProduct:
   case varGeneProductAssociation:
@@ -1233,6 +1261,7 @@ bool Variable::SetFormula(Formula* formula, bool isObjective)
   case varSpeciesUndef:
   case varUncertWrapper:
   case varLayoutWrapper:
+  case varKineticLawWrapper:
   case varStoichiometry:
     if (m_formulatype == formulaASSIGNMENT) {
       g_registry.SetError("Cannot set '" + GetNameDelimitedBy(".") + "' to have the initial value '" + formula->ToDelimitedStringWithEllipses(".") + "' because it already has an assignment rule, which applies at all times, including time=0.");
@@ -1711,6 +1740,12 @@ bool Variable::SetIsConst(bool constant)
           return true;
       }
       break;
+  case varKineticLawWrapper:
+      if (!constant) {
+          g_registry.SetError(error + ", as 'constantness' is undefined for kinetic law parameters.");
+          return true;
+      }
+      break;
   case varLayoutColorEtc:
       if (!constant) {
           g_registry.SetError(error + ", as 'constantness' is undefined for things like colors.");
@@ -1811,6 +1846,7 @@ bool Variable::SetSuperCompartment(Variable* var, var_type supertype)
   case varSboTermWrapper:
   case varUncertWrapper:
   case varLayoutWrapper:
+  case varKineticLawWrapper:
   case varConstraint:
   case varStoichiometry:
   case varAlgebraicRule:
@@ -1866,6 +1902,7 @@ void Variable::SetComponentCompartments(bool frommodule)
   case varSboTermWrapper:
   case varUncertWrapper:
   case varLayoutWrapper:
+  case varKineticLawWrapper:
   case varConstraint:
   case varStoichiometry:
   case varAlgebraicRule:
@@ -2096,6 +2133,7 @@ bool Variable::DeleteFromSubmodel(Variable* deletedvar)
   case varSboTermWrapper:
   case varUncertWrapper:
   case varLayoutWrapper:
+  case varKineticLawWrapper:
   case varConstraint:
   case varLayoutColorEtc:
   case varGeneProduct:
@@ -2656,6 +2694,27 @@ string Variable::CreateLayoutParamsAntimonySyntax(const string& indent) const
     return retval;
 }
 
+const KineticLawWrapper* Variable::GetKineticLawWrapper() const
+{
+  return m_kineticLawWrapper;
+}
+
+string Variable::CreateKineticLawSBOTermAntimonySyntax(const string& indent, string cc) const
+{
+  if (!m_kineticLawWrapper) {
+    return "";
+  }
+  return m_kineticLawWrapper->CreateSBOTermsAntimonySyntax(m_kineticLawWrapper->GetNameDelimitedBy(cc), indent, "sboTerm");
+}
+
+string Variable::CreateKineticLawCVTermsAntimonySyntax(const string& indent, string cc) const
+{
+  if (!m_kineticLawWrapper) {
+    return "";
+  }
+  return m_kineticLawWrapper->CreateCVTermsAntimonySyntax(m_kineticLawWrapper->GetNameDelimitedBy(cc), indent);
+}
+
 bool Variable::AllowedInFormulas() const
 {
   switch (m_type) {
@@ -2681,6 +2740,7 @@ bool Variable::AllowedInFormulas() const
   case varSboTermWrapper:
   case varUncertWrapper:
   case varLayoutWrapper:
+  case varKineticLawWrapper:
   case varConstraint:
   case varAlgebraicRule:
   case varGeneProductAssociation:

--- a/src/variable.h
+++ b/src/variable.h
@@ -24,6 +24,7 @@ class UnitDef;
 class SboTermWrapper;
 class UncertWrapper;
 class LayoutWrapper;
+class KineticLawWrapper;
 
 class Variable : public Annotated
 {
@@ -66,6 +67,7 @@ protected:
   SboTermWrapper* m_sboTermWrapper;
   std::vector<UncertWrapper*> m_uncertWrappers;
   std::vector<LayoutWrapper*> m_layoutWrappers;
+  KineticLawWrapper* m_kineticLawWrapper = NULL;
   //If we've set the compartment we're in, this tells us where we are.
   std::vector<std::string> m_compartment;
   std::vector<std::string> m_supercompartment;
@@ -125,6 +127,7 @@ public:
   const AntimonyConstraint* GetConstraint() const;
 
   virtual Variable* GetSubVariable(const std::string* name);
+  const KineticLawWrapper* GetKineticLawWrapper() const;
   virtual Variable* GetSameVariable();
   virtual const Variable* GetSameVariable() const;
   const DNAStrand* GetDNAStrand() const;
@@ -222,6 +225,9 @@ public:
   virtual std::string CreateSBOTermsAntimonySyntax(const std::string& elt_id, const std::string& indent, std::string sboStr) const;
   virtual std::string CreateUncertParamsAntimonySyntax(const std::string& indent) const;
   virtual std::string CreateLayoutParamsAntimonySyntax(const std::string& indent) const;
+  // SBO term and CV terms set on 'reaction.kineticLaw', if any.
+  std::string CreateKineticLawSBOTermAntimonySyntax(const std::string& indent, std::string cc) const;
+  std::string CreateKineticLawCVTermsAntimonySyntax(const std::string& indent, std::string cc) const;
 
   bool AllowedInFormulas() const;
 


### PR DESCRIPTION
i.e. 'J0.kineticLaw.sboTerm = 24' or 'J0.kineticLaw hasVersion "url"'.

Fix for #87 and #58.

This is largely a Claude design, but it follows existing code faithfully, and was hand-checked.